### PR TITLE
provide access to warnings as objects (see issue #14)

### DIFF
--- a/parse/abc_parse.js
+++ b/parse/abc_parse.js
@@ -71,6 +71,12 @@ window.ABCJS.parse.Parse = function() {
 		multilineVars.warnings.push(str);
 	};
 
+	var addWarningObject = function(warningObject) {
+		if (!multilineVars.warningObjects)
+			multilineVars.warningObjects = [];
+		multilineVars.warningObjects.push(warningObject);
+	};
+
 	var encode = function(str) {
 		var ret = window.ABCJS.parse.gsub(str, '\x12', ' ');
 		ret = window.ABCJS.parse.gsub(ret, '&', '&amp;');
@@ -86,11 +92,15 @@ window.ABCJS.parse.Parse = function() {
 			'<span style="text-decoration:underline;font-size:1.3em;font-weight:bold;">' + bad_char + '</span>' +
 			encode(line.substring(col_num+1));
 		addWarning("Music Line:" + tune.getNumLines() + ":" + (col_num+1) + ': ' + str + ":  " + clean_line);
+		addWarningObject({message:str, line:line, startChar: multilineVars.iChar + col_num, column: col_num});
 	};
 	var header = new window.ABCJS.parse.ParseHeader(tokenizer, warn, multilineVars, tune);
 
 	this.getWarnings = function() {
 		return multilineVars.warnings;
+	};
+	this.getWarningObjects = function() {
+		return multilineVars.warningObjects;
 	};
 
 	var letter_to_chord = function(line, i)


### PR DESCRIPTION
HI Paul, I have implemented issue #14 as far as I was able to. It boils down to a new method in ABCJS.parser.getWarningObjects which yields an array of objects

  {
   message:str,       // the error message 
   line:line,              // the broken line
   startChar: multilineVars.iChar + col_num, // the startChar of the error
   column: col_num  // the position of the error within line
 }

Based on this, i was able to highlight the error position in my editor.

As this API does not break backwards compatibility at all, I kindly ask you to incorporate it.
