### PR TITLE
Correct order of timing events for animation

### DIFF
--- a/api/abc_animation.js
+++ b/api/abc_animation.js
@@ -107,7 +107,14 @@ if (!window.ABCJS)
 					arr.push(hash[k]);
 			}
 			arr = arr.sort(function(a,b) {
-				return a.time - b.time;
+				var diff = a.time - b.time;
+				// if the events have the same time, make sure a bar comes before a note
+				if (diff !== 0) {
+					return diff;
+				}
+				else {
+					return a.type === "bar" ? -1 : 1;
+				}
 			});
 			return arr;
 		}


### PR DESCRIPTION
In `ABCJS.startAnimation()`, the `makeSortedArray()` function sorts the event hash by time, but it doesn't account for the scenario where a note can precede a bar with the same time value in the original unsorted array. In this scenario, because the time difference is 0, the note will precede the bar, which causes problems for the animation (in my experience, ABCJS believes the measure before the bar to contain an extra note which should actually be in the measure after the bar). To solve this, I've added a few lines to check whether the time difference is 0, and if it is, to make sure the bar comes first. This should address #27.