### PR TITLE
If no meter is specified, free meter is assumed

### DIFF
--- a/parse/abc_parse.js
+++ b/parse/abc_parse.js
@@ -50,7 +50,7 @@ window.ABCJS.parse.Parse = function() {
 			}
 			this.iChar = 0;
 			this.key = {accidentals: [], root: 'none', acc: '', mode: '' };
-			this.meter = {type: 'specified', value: [{num: '4', den: '4'}]};	// if no meter is specified, there is an implied one.
+			this.meter = null; // if no meter is specified, free meter is assumed
 			this.origMeter = {type: 'specified', value: [{num: '4', den: '4'}]};	// this is for new voices that are created after we set the meter.
 			this.hasMainTitle = false;
 			this.default_length = 0.125;


### PR DESCRIPTION
According to http://abcnotation.com/wiki/abc:standard:v2.1#mmeter

> When there is no M: field defined, free meter is assumed