### PR TITLE
L: 1 (whole note) should be accepted as note length

### DIFF
--- a/parse/abc_parse_header.js
+++ b/parse/abc_parse_header.js
@@ -201,6 +201,9 @@ window.ABCJS.parse.ParseHeader = function(tokenizer, warn, multilineVars, tune) 
 				multilineVars.default_length = n / d;	// a whole note is 1
 				multilineVars.havent_set_length = false;
 			}
+		} else if (len_arr.length === 1 && len_arr[0] === '1') {
+			multilineVars.default_length = 1;
+			multilineVars.havent_set_length = false;
 		}
 	};
 


### PR DESCRIPTION
According to http://abcnotation.com/wiki/abc:standard:v2.1#lunit_note_length

> L:1 (whole note) (...) are also available