### PR TITLE
Do not change the default note length when meter is change inline

### DIFF
--- a/parse/abc_parse_header.js
+++ b/parse/abc_parse_header.js
@@ -45,32 +45,46 @@ window.ABCJS.parse.ParseHeader = function(tokenizer, warn, multilineVars, tune) 
 	this.setMeter = function(line) {
 		line = tokenizer.stripComment(line);
 		if (line === 'C') {
-			if (multilineVars.havent_set_length === true)
+			if (multilineVars.havent_set_length === true) {
 				multilineVars.default_length = 0.125;
+				multilineVars.havent_set_length = false;
+			}
 			return {type: 'common_time'};
 		} else if (line === 'C|') {
-			if (multilineVars.havent_set_length === true)
+			if (multilineVars.havent_set_length === true) {
 				multilineVars.default_length = 0.125;
+				multilineVars.havent_set_length = false;
+			}
 			return {type: 'cut_time'};
 		} else if (line === 'o') {
-			if (multilineVars.havent_set_length === true)
+			if (multilineVars.havent_set_length === true) {
 				multilineVars.default_length = 0.125;
+				multilineVars.havent_set_length = false;
+			}
 			return {type: 'tempus_perfectum'};
 		} else if (line === 'c') {
-			if (multilineVars.havent_set_length === true)
+			if (multilineVars.havent_set_length === true) {
 				multilineVars.default_length = 0.125;
+				multilineVars.havent_set_length = false;
+			}
 			return {type: 'tempus_imperfectum'};
 		} else if (line === 'o.') {
-			if (multilineVars.havent_set_length === true)
+			if (multilineVars.havent_set_length === true) {
 				multilineVars.default_length = 0.125;
+				multilineVars.havent_set_length = false;
+			}
 			return {type: 'tempus_perfectum_prolatio'};
 		} else if (line === 'c.') {
-			if (multilineVars.havent_set_length === true)
+			if (multilineVars.havent_set_length === true) {
 				multilineVars.default_length = 0.125;
+				multilineVars.havent_set_length = false;
+			}
 			return {type: 'tempus_imperfectum_prolatio'};
 		} else if (line.length === 0 || line.toLowerCase() === 'none') {
-			if (multilineVars.havent_set_length === true)
+			if (multilineVars.havent_set_length === true) {
 				multilineVars.default_length = 0.125;
+				multilineVars.havent_set_length = false;
+			}
 			return null;
 		}
 		else
@@ -133,6 +147,7 @@ window.ABCJS.parse.ParseHeader = function(tokenizer, warn, multilineVars, tune) 
 
 				if (multilineVars.havent_set_length === true) {
 					multilineVars.default_length = totalLength < 0.75 ? 0.0625 : 0.125;
+					multilineVars.havent_set_length = false;
 				}
 				return meter;
 			} catch (e) {


### PR DESCRIPTION
For example :
````
M: 4/4
C8 | [M: 2/4] C8
````
Both Cs should have a length of 1. Because according to http://abcnotation.com/wiki/abc:standard:v2.1#lunit_note_length

>If there is no L: field defined, a unit note length is set by default, based on the meter field M:. (...)
>**A meter change within the body of the tune will not change the unit note length**.