### PR TITLE
Add custom class to generated MIDI download div

### DIFF
--- a/src/midi/abc_midi_controls.js
+++ b/src/midi/abc_midi_controls.js
@@ -46,7 +46,10 @@ var midi = {};
 	}
 
 	midi.generateMidiDownloadLink = function(tune, midiParams, midi, index) {
-		var html = '<div class="download-midi midi-' + index + '">';
+		var divClasses = ['download-midi', 'midi-' + index]
+		if (midiParams.downloadClass)
+			divClasses.push(midiParams.downloadClass)
+		var html = '<div class="' + divClasses.join(' ') + '">';
 		if (midiParams.preTextDownload)
 			html += midiParams.preTextDownload;
 		var title = tune.metaText && tune.metaText.title ? tune.metaText.title : 'Untitled';


### PR DESCRIPTION
This allows MIDI download link styling using an arbitrary class name. Especially useful for adopting classes provided by a CSS framework, and so using consistent class names across the site.
