### PR TITLE
Make extraMeasuresAtBeginning default to 0

### DIFF
--- a/src/api/abc_timing_callbacks.js
+++ b/src/api/abc_timing_callbacks.js
@@ -3,7 +3,7 @@ var TimingCallbacks = function(target, params) {
 	var self = this;
 	if (!params) params = {};
 	var qpm = params.qpm;
-	var extraMeasuresAtBeginning = params.extraMeasuresAtBeginning;
+	var extraMeasuresAtBeginning = params.extraMeasuresAtBeginning ? params.extraMeasuresAtBeginning : 0;
 	self.beatCallback = params.beatCallback; // This is called for each beat.
 	self.eventCallback = params.eventCallback;   // This is called for each note or rest encountered.
 


### PR DESCRIPTION
If `extraMeasuresAtBeginning` is not set in param make it 0 as in the API documentation.