### PR TITLE
New functionalities around progress bar 

### DIFF
--- a/abcjs-midi.css
+++ b/abcjs-midi.css
@@ -76,12 +76,12 @@
 	content: "\f04c"; /*   fa-play [&#xf04b;]    fa-pause [&#xf04c;] */
 }
 
-.abcjs-inline-midi .abcjs-midi-start.abcjs-pushed.abcjs-loading {
+.abcjs-inline-midi .abcjs-midi-start.abcjs-loading {
 	outline: none;
 	animation: a 1s infinite steps(8);
 }
 
-.abcjs-inline-midi .abcjs-midi-start.abcjs-pushed.abcjs-loading:before {
+.abcjs-inline-midi .abcjs-midi-start.abcjs-loading:before {
 	content: "\f110"; /*   fa-loading */
 }
 

--- a/midi.js
+++ b/midi.js
@@ -29,6 +29,7 @@ abcjs.midi = {
 	setLoop: midi.setLoop,
 	deviceSupportsMidi: midi.deviceSupportsMidi,
 	setRandomProgress: midi.setRandomProgress,
+	setInteractiveProgressBar: midi.setInteractiveProgressBar
 };
 
 module.exports = abcjs;

--- a/src/midi/abc_midi_controls.js
+++ b/src/midi/abc_midi_controls.js
@@ -137,6 +137,11 @@ var midi = {};
 		soundfontUrl = url;
 	};
 
+	var interactiveProgressBar = true;
+	midi.setInteractiveProgressBar = function(interactive) {
+		interactiveProgressBar = interactive;
+	};
+
 	function hasClass(element, cls) {
 		if (!element)
 			return false;
@@ -600,7 +605,9 @@ var midi = {};
 					onReset(target, event);
 					return;
 				} else if (hasClass(target, 'abcjs-midi-progress-background')) {
-					onProgress(target, event);
+					if(interactiveProgressBar) {
+						onProgress(target, event);
+					}
 					return;
 				}
 				target = target.parentNode;
@@ -619,13 +626,14 @@ var midi = {};
 		document.body.addEventListener("mousedown", function(event) {
 			event = event || window.event;
 			var target = event.target || event.srcElement;
-			if (hasClass(target, 'abcjs-midi-progress-indicator')) {
-				dragIndicator = target;
-				isIndicatorPressed = true;
-				dragParent = closest(target, 'abcjs-midi-progress-background');
+			if(interactiveProgressBar) {
+				if (hasClass(target, 'abcjs-midi-progress-indicator')) {
+					dragIndicator = target;
+					isIndicatorPressed = true;
+					dragParent = closest(target, 'abcjs-midi-progress-background');
+				}
 			}
 		});
-
 
 		document.addEventListener('mousemove', function(event) {
 			event.preventDefault();


### PR DESCRIPTION
These 2 commits add 2 different functionality:

4c043a7: Move the indicator in the correct position after clicking on the progress bar
53e4e00: Allow users to drag the indicator along the progress bar