### PR TITLE
Fix mousemove listener, we want to consume only our events

### DIFF
--- a/src/midi/abc_midi_controls.js
+++ b/src/midi/abc_midi_controls.js
@@ -636,9 +636,9 @@ var midi = {};
 		});
 
 		document.addEventListener('mousemove', function(event) {
-			event.preventDefault();
 			if (isIndicatorPressed) {
 				event = event || window.event;
+				event.preventDefault();
 				var pos = relMouseX(dragParent, event);
 				dragIndicator.style.left = pos + 'px';
 			}


### PR DESCRIPTION
As posted here: https://github.com/paulrosen/abcjs/commit/53e4e009dfb3d1f814b5760bafa70bac5de7b958#commitcomment-31855812