### PR TITLE
invert beatCallback and timingCallback events

### DIFF
--- a/src/api/abc_timing_callbacks.js
+++ b/src/api/abc_timing_callbacks.js
@@ -91,6 +91,11 @@ var TimingCallbacks = function(target, params) {
 		} else {
 			var currentTime = timestamp - self.startTime;
 			currentTime += 50; // Add a little slop because this function isn't called exactly.
+			while (self.noteTimings.length > self.currentEvent && self.noteTimings[self.currentEvent].milliseconds < currentTime) {
+				if (self.eventCallback && self.noteTimings[self.currentEvent].type === 'event')
+					self.eventCallback(self.noteTimings[self.currentEvent]);
+				self.currentEvent++;
+			}
 			if (currentTime < self.lastMoment) {
 				requestAnimationFrame(self.doTiming);
 				if (self.currentBeat * self.millisecondsPerBeat < currentTime) {
@@ -104,11 +109,6 @@ var TimingCallbacks = function(target, params) {
 					self.currentBeat++;
 					requestAnimationFrame(self.doTiming);
 				}
-			}
-			while (self.noteTimings.length > self.currentEvent && self.noteTimings[self.currentEvent].milliseconds < currentTime) {
-				if (self.eventCallback && self.noteTimings[self.currentEvent].type === 'event')
-					self.eventCallback(self.noteTimings[self.currentEvent]);
-				self.currentEvent++;
 			}
 
 			if (self.lineEndCallback && self.lineEndTimings.length && self.lineEndTimings[0].milliseconds <= currentTime) {


### PR DESCRIPTION
I found convenient to have the measureNumber when handling some sort of manipulation of beat numbers (dealing with visual progress bar, in my specific case).
Though, beatCallback doesn't have a reference to the current measure, and it get a bit weird to recalculate (thinking about repetition and such).
So, my proposal is to invert the order of timingCallback and beatCallback in order to get as soon as possible tune informations  (note, line, measures...) and then eventually beats.