### PR TITLE
protect from getBbox exceptions if element not visible

### DIFF
--- a/src/write/abc_renderer.js
+++ b/src/write/abc_renderer.js
@@ -355,7 +355,12 @@ Renderer.prototype.engraveExtraText = function(width, abctune) {
 				for (var k = 0; k < abctune.metaText.unalignedWords[j].length; k++) {
 					var type = (abctune.metaText.unalignedWords[j][k].font) ? abctune.metaText.unalignedWords[j][k].font : "wordsfont";
 					var el = this.renderText(this.padding.left + spacing.INDENT + offsetX, this.y, abctune.metaText.unalignedWords[j][k].text, type, 'meta-bottom', false);
-					var size = el.getBBox();
+					var size;
+					try {
+						size = el.getBBox();
+					} catch(e) {
+						size = { width: 0, height: 0 };
+					}
 					largestY = Math.max(largestY, size.height);
 					offsetX += size.width;
 					// If the phrase ends in a space, then that is not counted in the width, so we need to add that in ourselves.
@@ -783,7 +788,12 @@ Renderer.prototype.renderText = function(x, y, text, type, klass, anchor, center
 	var el = this.paper.text(text, hash.attr);
 
 	if (hash.font.box) {
-		var size = el.getBBox();
+		var size;
+                try {
+                        size = el.getBBox();
+                } catch(e) {
+                        size = { width: 0, height: 0 };
+                }
 		var padding = 2;
 		var margin = 2;
 		this.paper.rect({ x: size.x - padding, y: size.y, width: size.width + padding*2, height: size.height + padding*2 - margin,  stroke: "#888888", fill: "transparent"});
@@ -810,7 +820,12 @@ Renderer.prototype.outputTextIf = function(x, str, kind, klass, marginTop, margi
 		if (marginTop)
 			this.moveY(marginTop);
 		var el = this.renderText(x, this.y, str, kind, klass, alignment);
-		var bb = el.getBBox(); // This can return NaN if the element isn't visible.
+		var bb;
+		try {
+			bb = el.getBBox(); // This can return NaN if the element isn't visible.
+		} catch(e) {
+			bb = { width: 0, height: 0 };
+		}
 		var width = isNaN(bb.width) ? 0 : bb.width;
 		var height = isNaN(bb.height) ? 0 : bb.height;
 		var hash = this.getFontAndAttr(kind, klass);
@@ -903,7 +918,12 @@ Renderer.prototype.printVerticalLine = function (x, y1, y2) {
  * @private
  */
 Renderer.prototype.addToRegression = function (el) {
-	var box = el.getBBox();
+	var box;
+	try {
+		box = el.getBBox();
+	} catch(e) {
+		box = { width: 0, height: 0 };
+	}
 	//var str = "("+box.x+","+box.y+")["+box.width+","+box.height+"] "
 	var str = el.type + ' ' + box.toString() + ' ';
 	var attrs = [];

--- a/src/write/abc_tempo_element.js
+++ b/src/write/abc_tempo_element.js
@@ -114,7 +114,10 @@ var TempoElement;
 		var text;
 		if (this.tempo.preString) {
 			text = renderer.renderText(x, y, this.tempo.preString, 'tempofont', 'tempo', "start");
-			var preWidth = text.getBBox().width;
+			var preWidth = 0;
+			try {
+				preWidth = text.getBBox().width;
+			} catch(ex) {}
 			var charWidth = preWidth / this.tempo.preString.length; // Just get some average number to increase the spacing.
 			x += preWidth + charWidth;
 		}
@@ -126,7 +129,10 @@ var TempoElement;
 			x += (this.note.w + 5);
 			var str = "= " + this.tempo.bpm;
 			text = renderer.renderText(x, y, str, 'tempofont', 'tempo', "start");
-			var postWidth = text.getBBox().width;
+			var postWidth = 0;
+			try {
+				postWidth = text.getBBox().width;
+			} catch(ex) {}
 			var charWidth2 = postWidth / str.length; // Just get some average number to increase the spacing.
 			x += postWidth + charWidth2;
 		}

--- a/src/write/svg.js
+++ b/src/write/svg.js
@@ -147,11 +147,16 @@ Svg.prototype.text = function(text, attr) {
 
 Svg.prototype.getTextSize = function(text, attr) {
 	var el = this.text(text, attr);
-	var size = el.getBBox();
-	if (isNaN(size.height)) // This can happen if the element isn't visible.
+	var size;
+	try {
+		size  = el.getBBox();
+		if (isNaN(size.height)) // This can happen if the element isn't visible.
+			size = { width: 0, height: 0};
+		else
+			size = { width: size.width, height: size.height };
+	} catch (ex) {
 		size = { width: 0, height: 0};
-	else
-		size = { width: size.width, height: size.height };
+	}
 	// TODO-PER: can the size be gotten without inserting and deleting the element?
 	if (this.currentGroup)
 		this.currentGroup.removeChild(el);


### PR DESCRIPTION
this branch addresses this behavior of Firefox:
https://stackoverflow.com/questions/45184101/error-ns-error-failure-in-firefox-while-use-getbbox

if SVG elements are not visible, getBBox raise an exception.
Basically we fixed enclosing all getBBox occurrences in try/catch.