### PR TITLE
Issue #237: setbarnb measure number

### DIFF
--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -112,13 +112,6 @@ var Parse = function() {
 				if (this.differentFont("measurefont", defaultFonts)) addFont(el, 'measurefont', this.measurefont);
 				if (this.differentFont("repeatfont", defaultFonts)) addFont(el, 'repeatfont', this.repeatfont);
 			}
-    },
-    setBarNumber: function(optBarNumber) {
-      if (optBarNumber !== undefined)
-        this.currBarNumber = optBarNumber;
-      else
-        this.currBarNumber = this.setbarnb;
-      delete this.setbarnb;
     }
 	};
 

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -112,7 +112,7 @@ var Parse = function() {
 				if (this.differentFont("measurefont", defaultFonts)) addFont(el, 'measurefont', this.measurefont);
 				if (this.differentFont("repeatfont", defaultFonts)) addFont(el, 'repeatfont', this.repeatfont);
 			}
-    }
+		}
 	};
 
 	var addWarning = function(str) {

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -112,7 +112,14 @@ var Parse = function() {
 				if (this.differentFont("measurefont", defaultFonts)) addFont(el, 'measurefont', this.measurefont);
 				if (this.differentFont("repeatfont", defaultFonts)) addFont(el, 'repeatfont', this.repeatfont);
 			}
-		}
+    },
+    setBarNumber: function(optBarNumber) {
+      if (optBarNumber !== undefined)
+        this.currBarNumber = optBarNumber;
+      else
+        this.currBarNumber = this.setbarnb;
+      delete this.setbarnb;
+    }
 	};
 
 	var addWarning = function(str) {

--- a/src/parse/abc_parse_directive.js
+++ b/src/parse/abc_parse_directive.js
@@ -772,9 +772,10 @@ var parseDirective = {};
 				if (scratch !== null) return scratch;
 				break;
 			case "setbarnb":
-				scratch = addMultilineVar('setbarnb', cmd, tokens);
-				if (scratch !== null) return scratch;
-				multilineVars.setBarNumber();
+				if (tokens.length !== 1 || tokens[0].type !== 'number') {
+					return 'Directive setbarnb requires a number as a parameter.';
+				}
+				multilineVars.currBarNumber = tokens[0].intt;
 				break;
 			case "begintext":
 				multilineVars.inTextBlock = true;

--- a/src/parse/abc_parse_directive.js
+++ b/src/parse/abc_parse_directive.js
@@ -771,6 +771,11 @@ var parseDirective = {};
 				scratch = addMultilineVar('barNumbers', cmd, tokens);
 				if (scratch !== null) return scratch;
 				break;
+			case "setbarnb":
+				scratch = addMultilineVar('setbarnb', cmd, tokens);
+				if (scratch !== null) return scratch;
+				multilineVars.setBarNumber();
+				break;
 			case "begintext":
 				multilineVars.inTextBlock = true;
 				break;


### PR DESCRIPTION
The draft implements the `%% setbarnb <integer>` pseudo comment.  The following examples demonstrate.

```
const melody = 
  '(!tenuto!A2 !tenuto!=B2) (!tenuto!^c2 .B.A) | B=2^f/2B/2 (A^F) F4 |' +
  '(=B A2 ^F) .E/2.E/2.A/2.^c/2 e4 |\n' +
  '(A2 =B2) (^c2 .B.A) | B=2^f/2B/2 (A^F) F4 |' +
  '(=B A2 ^F) .E/2.E/2.A/2.^C/2 E4 |';

const example0 = 'X:2\nL: 1/8\nL: 1/8\nK:F clef=treble\nT:No. 12 excerpt (violin 1)\n%%setbarnb 44\n%%barnumbers 2\n' + melody;
ABCJS.renderAbc('example0', example0);
  
const example1 = 'X:2\nL: 1/8\nL: 1/8\nK:F clef=treble\nT:No setbarnb\n%%barnumbers 2\n' + melody;
ABCJS.renderAbc('example1', example1);

const example2 = 'X:2\nL: 1/8\nL: 1/8\nK:F clef=treble\nT:No barnumbers\n%%setbarnb 44\n' + melody;
ABCJS.renderAbc('example2', example2);

const example3 = 'X:2\nL: 1/8\nL: 1/8\nK:F clef=treble\nT:No residual side effects\n' + melody;
ABCJS.renderAbc('example3', example3);

const example4 = 'X:2\nL: 1/8\nL: 1/8\nK:F clef=treble\nT:Line number "four"\n\n%%setbarnb four\n%%barnumbers 2\n' + melody;
ABCJS.renderAbc('example4', example4);

const melodyLineNum = 
    '(!tenuto!A2 !tenuto!=B2) (!tenuto!^c2 .B.A) | B=2^f/2B/2 (A^F) F4 |' +
    '(=B A2 ^F) .E/2.E/2.A/2.^c/2 e4 |\n' +
    '%% setbarnb 12\n' +
    '(A2 =B2) (^c2 .B.A) | B=2^f/2B/2 (A^F) F4 |' +
    '(=B A2 ^F) .E/2.E/2.A/2.^C/2 E4 |';
const example5 = 'X:2\nL: 1/8\nL: 1/8\nK:F clef=treble\nT:Line updates\n%%barnumbers 1\n' + melodyLineNum;
ABCJS.renderAbc('example5', example5);
```

The latter demonstrates that the bar number is printed before the pseudocomment is applied for the updated bar 12.  If the bug is a show stopper, I will withdraw the PR.  As a user, the work around is to use the directive one line early (easy), but a more-comprehensive fix is probably beyond my familiarity with abcjs.