### PR TITLE
Don't ignore chord basses with accidentals when generating midi

### DIFF
--- a/src/midi/abc_midi_flattener.js
+++ b/src/midi/abc_midi_flattener.js
@@ -560,9 +560,11 @@ var flatten;
 		var arr = remaining.split('/');
 		chick = chordNotes(bass, arr[0]);
 		if (arr.length === 2) {
-			var explicitBass = basses[arr[1]];
+			var explicitBass = basses[arr[1].substring(0,1)];
 			if (explicitBass) {
-				bass = basses[arr[1]] + transpose;
+				var bassAcc = arr[1].substring(1);
+				var bassShift = {'#': 1, '♯': 1, 'b': -1, '♭': -1}[bassAcc] || 0;
+				bass = basses[arr[1].substring(0,1)] + bassShift + transpose;
 				bass2 = bass;
 			}
 		}


### PR DESCRIPTION
I try to make a fix for #278 

The codes take the first letter of an explicit bass note to decide its pitch (instead of using the whole text of the bass note to match for pitches, which makes it ignores the bass notes with accidentals). Thereafter, the bass pitch is shifted by the accidental (if any).