### PR TITLE
fix wrapLines with several titles

### DIFF
--- a/src/parse/wrap_lines.js
+++ b/src/parse/wrap_lines.js
@@ -30,6 +30,7 @@ function wrapLines(tune, lineBreaks) {
 	var measureMarker = [];
 	var lastMeter = '';
 	var voiceStart = {};
+	var linesWithoutStaff = 0;
 
 	for (var i = 0; i < tune.lines.length; i++) {
 		var line = tune.lines[i];
@@ -51,6 +52,7 @@ function wrapLines(tune, lineBreaks) {
 						measureNumber[j][k] = 0;
 						measureMarker[j][k] = 0;
 					}
+					if (linesWithoutStaff > 0) currentLine[j][k] += linesWithoutStaff;
 					var voice = voices[k];
 					for (var e = 0; e < voice.length; e++) {
 						if (startNewLine[j][k]) {
@@ -103,9 +105,10 @@ function wrapLines(tune, lineBreaks) {
 
 				}
 			}
+			linesWithoutStaff = 0;
 		} else {
 			newLines.push(line);
-			currentLine++;
+			linesWithoutStaff++;
 		}
 	}
 	tune.lines = newLines;


### PR DESCRIPTION
if change script tag in examples\basic.html  as below error raised in src\parse\wrap_lines.js

`
	<script type="text/javascript">
		var abc = "T: Cooley's\n" +  
			"T: SubTitle\n" +
			"M: 4/4\n" +
			"L: 1/8\n" +
			"R: reel\n" +
			"K: Emin\n" +
			"|:D2|EB{c}BA B2 EB|~B2 AB dBAG|FDAD BDAD|FDAD dAFD|\n" +
			"EBBA B2 EB|B2 AB defg|afe^c dBAF|DEFD E2:|\n" +
			"|:gf|eB B2 efge|eB B2 gedB|A2 FA DAFA|A2 FA defg|\n" +
			"eB B2 eBgB|eB B2 defg|afe^c dBAF|DEFD E2:|";

		function load() {
			ABCJS.renderAbc("paper", abc, {  
				staffwidth: 800,
				wrap: { minSpacing: 1.8, maxSpacing: 2.7, preferredMeasuresPerLine: 4 },
			});
		}

	</script>
`
