### PR TITLE
Improve downward stem and beam rendering

### DIFF
--- a/src/write/abc_beam_element.js
+++ b/src/write/abc_beam_element.js
@@ -235,7 +235,7 @@ var BeamElem;
 		var startX = starthead.x;
 		if (asc) startX += starthead.w - 0.6;
 		var endX = endhead.x;
-		if (asc) endX += endhead.w;
+		endX += (asc) ? endhead.w : 0.6;
 		return [ startX, endX ];
 	}
 

--- a/src/write/abc_renderer.js
+++ b/src/write/abc_renderer.js
@@ -618,7 +618,7 @@ Renderer.prototype.printStaveLine = function (x1,x2, pitch, klass) {
  * @param {number} y2 y coordinate of the stem top
  */
 Renderer.prototype.printStem = function (x, dx, y1, y2) {
-  if (dx<0) { // correct path "handedness" for intersection with other elements
+  if (dx<0 || y1<y2) { // correct path "handedness" for intersection with other elements
     var tmp = y2;
     y2 = y1;
     y1 = tmp;


### PR DESCRIPTION
This fixes the rendering of downward beamed stems and the beam being drawn short of the stem.

![image](https://user-images.githubusercontent.com/31827535/83596806-da68e500-a522-11ea-90a6-ee92d9fae000.png)
![image](https://user-images.githubusercontent.com/31827535/83596764-ba392600-a522-11ea-9ab9-01032e61d10b.png)

