### PR TITLE
add slurgraces option

### DIFF
--- a/src/write/abc_abstract_engraver.js
+++ b/src/write/abc_abstract_engraver.js
@@ -65,6 +65,7 @@ AbstractEngraver = function(renderer, tuneNumber, options) {
 	this.tuneNumber = tuneNumber;
 	this.isBagpipes = options.bagpipes;
 	this.flatBeams = options.flatbeams;
+	this.slurGraces = options.slurgraces;
 	this.reset();
 };
 
@@ -512,7 +513,7 @@ var ledgerLines = function(abselem, minPitch, maxPitch, isRest, symbolWidth, add
 			}
 			ledgerLines(abselem, gracepitch, gracepitch, false, glyphs.getSymbolWidth("noteheads.quarter"), [], true, grace.dx - 1, 0.6);
 
-			if (i === 0 && !isBagpipes && !(elem.rest && (elem.rest.type === "spacer" || elem.rest.type === "invisible"))) {
+			if (!this.slurGraces && (i === 0 && !isBagpipes && !(elem.rest && (elem.rest.type === "spacer" || elem.rest.type === "invisible")))) {
 				// This is the overall slur that is under the grace notes.
 				var isTie = (elem.gracenotes.length === 1 && grace.pitch === notehead.pitch);
 				voice.addOther(new TieElem({ anchor1: grace, anchor2: notehead, isGrace: true}));

--- a/src/write/abc_engraver_controller.js
+++ b/src/write/abc_engraver_controller.js
@@ -121,7 +121,11 @@ EngraverController.prototype.getMeasureWidths = function(abcTune) {
 	this.renderer.lineNumber = null;
 
 	this.renderer.newTune(abcTune);
-	this.engraver = new AbstractEngraver(this.renderer, 0, { bagpipes: abcTune.formatting.bagpipes, flatbeams: abcTune.formatting.flatbeams });
+	this.engraver = new AbstractEngraver(this.renderer, 0, {
+		bagpipes: abcTune.formatting.bagpipes,
+		flatbeams: abcTune.formatting.flatbeams,
+		slurgraces: abcTune.formatting.slurgraces
+	});
 	this.engraver.setStemHeight(this.renderer.spacing.stemHeight);
 	if (abcTune.formatting.staffwidth) {
 		this.width = abcTune.formatting.staffwidth * 1.33; // The width is expressed in pt; convert to px.
@@ -180,7 +184,11 @@ EngraverController.prototype.engraveTune = function (abctune, tuneNumber) {
 	this.renderer.lineNumber = null;
 
 	this.renderer.newTune(abctune);
-	this.engraver = new AbstractEngraver(this.renderer, tuneNumber, { bagpipes: abctune.formatting.bagpipes, flatbeams: abctune.formatting.flatbeams });
+	this.engraver = new AbstractEngraver(this.renderer, tuneNumber, {
+		bagpipes: abctune.formatting.bagpipes,
+		flatbeams: abctune.formatting.flatbeams,
+		slurgraces: abctune.formatting.slurgraces
+	});
 	this.engraver.setStemHeight(this.renderer.spacing.stemHeight);
 	this.engraver.measureLength = abctune.getMeterFraction().num/abctune.getMeterFraction().den;
 	if (abctune.formatting.staffwidth) {


### PR DESCRIPTION
this adds the ```%%slurgraces``` flag, however i've negated the flag to keep the current default visual.

I'm not sure whether this is the correct default or not.

I'm also unsure whether this would be better to be ```%%slurgraces``` to more closely match the notation section [here](http://abcnotation.com/wiki/abc:standard:v2.1#miscellaneous_directives)