### PR TITLE
fix to scale the click coords when paper is set to responsive

### DIFF
--- a/src/write/selection.js
+++ b/src/write/selection.js
@@ -35,12 +35,22 @@ function setupSelection(engraver) {
 }
 
 function getCoord(ev, svg) {
-  // svg.height and svg.width give element height and width in chrome
-	var scaleY = svg.viewBox.baseVal.height / svg.clientHeight
-	var scaleX = svg.viewBox.baseVal.width / svg.clientWidth
+  var scaleX = 1;
+  var scaleY = 1;
+
+  // when renderer.options.responsive === 'resize' the click coords are in relation to the HTML
+  // element, we need to convert to the SVG viewBox coords
+  if (svg.viewBox.baseVal) { // Firefox passes null to this when no viewBox is given
+    // Chrome makes these values null when no viewBox is given.
+    if (svg.viewBox.baseVal.width !== 0)
+      scaleX = svg.viewBox.baseVal.width / svg.clientWidth
+    if (svg.viewBox.baseVal.height !== 0)
+      scaleY = svg.viewBox.baseVal.height / svg.clientHeight
+  }
 
 	var x = ev.offsetX * scaleX;
 	var y = ev.offsetY * scaleY;
+  //console.log(x, y)
 
 	// The target might be the SVG that we want, or it could be an item in the SVG (usually a path). If it is not the SVG then
 	// add an offset to the coordinates.

--- a/src/write/selection.js
+++ b/src/write/selection.js
@@ -34,9 +34,13 @@ function setupSelection(engraver) {
 	engraver.renderer.paper.svg.addEventListener('mouseup', mouseUp.bind(engraver));
 }
 
-function getCoord(ev) {
-	var x = ev.offsetX;
-	var y = ev.offsetY;
+function getCoord(ev, svg) {
+	var scaleY = svg.height.baseVal.value / svg.clientHeight
+	var scaleX = svg.width.baseVal.value / svg.clientWidth
+
+	var x = ev.offsetX * scaleX;
+	var y = ev.offsetY * scaleY;
+
 	// The target might be the SVG that we want, or it could be an item in the SVG (usually a path). If it is not the SVG then
 	// add an offset to the coordinates.
 	// if (ev.target.tagName.toLowerCase() !== 'svg') {
@@ -120,7 +124,7 @@ function keyboardSelection(ev) {
 function mouseDown(ev) {
 	// "this" is the EngraverController because of the bind(this) when setting the event listener.
 
-	var box = getCoord(ev);
+	var box = getCoord(ev, this.renderer.paper.svg);
 	var x = box[0];
 	var y = box[1];
 
@@ -180,7 +184,7 @@ function mouseMove(ev) {
 	if (!this.dragTarget || !this.dragging || !this.dragTarget.isDraggable || this.dragMechanism !== 'mouse')
 		return;
 
-	var box = getCoord(ev);
+	var box = getCoord(ev, this.renderer.paper.svg);
 	var x = box[0];
 	var y = box[1];
 

--- a/src/write/selection.js
+++ b/src/write/selection.js
@@ -35,8 +35,9 @@ function setupSelection(engraver) {
 }
 
 function getCoord(ev, svg) {
-	var scaleY = svg.height.baseVal.value / svg.clientHeight
-	var scaleX = svg.width.baseVal.value / svg.clientWidth
+  // svg.height and svg.width give element height and width in chrome
+	var scaleY = svg.viewBox.baseVal.height / svg.clientHeight
+	var scaleX = svg.viewBox.baseVal.width / svg.clientWidth
 
 	var x = ev.offsetX * scaleX;
 	var y = ev.offsetY * scaleY;


### PR DESCRIPTION
This PR fixes an issue with selecting notes when the renderer is set to responsive I've only tested this on firefox.
It might be worth checking the svg element actually has these attributes before calculating the scaled values?

Basically what happens is when the renderer is set to responsive the mouse click coords are used which relate to the clicked elements X and Y. What should be used is the rendered svg viewport X and Y as the element and the viewport can be different widths and height.

Also just on a side note i didnt think it was worth posting an issue. I was wondering if youd be open to using something like [standard](https://standardjs.com/) or setting up eslint to format the code base somewhat? I know this can be very opinionated so thought id ask before looking into it?
