### PR TITLE
use https link over ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/.vuepress/dist"]
   path = docs/.vuepress/dist
-  url = git@github.com:paulrosen/abcjs.git
+  url = https://github.com/paulrosen/abcjs.git


### PR DESCRIPTION
I am using my own fork of abcjs with a few modifications to create somewhat of a swiss style drumming notation.
When running a github action to build a project using `npm ci`
with the dependency set to `"abcjs": "git+https://github.com/8633brown/abcjs.git#swiss"`
Npm fails to clone the docs directory as its a submodule.

`npm ERR! fatal: clone of 'git@github.com:paulrosen/abcjs.git' into submodule path '/home/runner/.npm/_cacache/tmp/git-clone-0a77afd7/docs/.vuepress/dist' failed
npm ERR! Failed to clone 'docs/.vuepress/dist'. Retry scheduled`

as far as i can understand, theres no reason for the submodule url to be an ssh type connection and https should suffice and fixes this issue. The only difference being the ssh url actually requires push access to the repo where as the https is read only. 

I'm not sure why npm even tries to clone the submodule to behonest as the docs folder is hidden by `.npmignore`.

<details>
<summary>Complete Error Message</summary>

```
npm ERR! code 1
npm ERR! Command failed: git submodule update -q --init --recursive
npm ERR! warning: templates not found in /tmp/pacote-git-template-tmp/git-clone-9d7107fa
npm ERR! git@github.com: Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
npm ERR! 
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.
npm ERR! fatal: clone of 'git@github.com:paulrosen/abcjs.git' into submodule path '/home/runner/.npm/_cacache/tmp/git-clone-0a77afd7/docs/.vuepress/dist' failed
npm ERR! Failed to clone 'docs/.vuepress/dist'. Retry scheduled
npm ERR! warning: templates not found in /tmp/pacote-git-template-tmp/git-clone-9d7107fa
npm ERR! Warning: Permanently added the RSA host key for IP address '140.82.114.3' to the list of known hosts.
npm ERR! git@github.com: Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
npm ERR! 
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.
npm ERR! fatal: clone of 'git@github.com:paulrosen/abcjs.git' into submodule path '/home/runner/.npm/_cacache/tmp/git-clone-0a77afd7/docs/.vuepress/dist' failed
npm ERR! Failed to clone 'docs/.vuepress/dist' a second time, aborting
npm ERR! 
```
</summary>