### PR TITLE
fix mangling of constructor names

### DIFF
--- a/src/write/draw/absolute.js
+++ b/src/write/draw/absolute.js
@@ -4,6 +4,8 @@ var spacing = require('../abc_spacing');
 var setClass = require('../set-class');
 var elementGroup = require('./group-elements');
 
+var tempoElem = require('../abc_tempo_element');
+
 function drawAbsolute(renderer, params, bartop) {
 	if (params.invisible) return;
 	params.elemset = [];
@@ -11,8 +13,8 @@ function drawAbsolute(renderer, params, bartop) {
 	for (var i=0; i<params.children.length; i++) {
 		var child = params.children[i];
 		var el;
-		switch (child.constructor.name) {
-			case 'TempoElement':
+		switch (child.constructor) {
+			case tempoElem:
 				el = drawTempo(renderer, child);
 				if (el)
 					params.elemset = params.elemset.concat(el);

--- a/src/write/draw/voice.js
+++ b/src/write/draw/voice.js
@@ -9,6 +9,13 @@ var renderText = require('./text');
 var drawAbsolute = require('./absolute');
 var parseCommon = require('../../parse/abc_common');
 
+var crescendoElem = require('../abc_crescendo_element');
+var dynamicDecorationElem = require('../abc_dynamic_decoration');
+var tripletElem = require('../abc_triplet_element');
+var endingElem = require('../abc_ending_element');
+var tieElem = require('../abc_tie_element');
+var tempoElem = require('../abc_tempo_element');
+
 function drawVoice(renderer, params, bartop) {
 	var width = params.w-1;
 	renderer.staffbottom = params.staff.bottom;
@@ -29,8 +36,8 @@ function drawVoice(renderer, params, bartop) {
 			justInitializedMeasureNumber = true;
 		}
 		renderer.controller.currentAbsEl = child;
-		switch (child.constructor.name) {
-			case 'TempoElement':
+		switch (child.constructor) {
+			case tempoElem:
 				child.elemset = drawTempo(renderer, child);
 				break;
 			default:
@@ -56,24 +63,24 @@ function drawVoice(renderer, params, bartop) {
 		if (child === 'bar') {
 			renderer.controller.classes.incrMeasure();
 		} else {
-			switch (child.constructor.name) {
-				case 'CrescendoElem':
+			switch (child.constructor) {
+				case crescendoElem:
 					child.elemset = drawCrescendo(renderer, child);
 					break;
-				case 'DynamicDecoration':
+				case dynamicDecorationElem:
 					child.elemset = drawDynamics(renderer, child);
 					break;
-				case 'TripletElem':
+				case tripletElem:
 					drawTriplet(renderer, child);
 					break;
-				case 'EndingElem':
+				case endingElem:
 					child.elemset = drawEnding(renderer, child, params.startx + 10, width);
 					break;
-				case 'TieElem':
+				case tieElem:
 					child.elemset = drawTie(renderer, child, params.startx + 10, width);
 					break;
 				default:
-					console.log(child.constructor.name)
+					console.log(child)
 					drawAbsolute(renderer, child, params.startx + 10, width);
 			}
 		}


### PR DESCRIPTION
currently the 6.0.11-beta minified versions are crashing from the separation of the draw functions from the classes.

as far as i can tell the minification is mangling the names and resulting in comparisons of ```object.constructor.name``` to fail as they will never match the correct switch statement. 

using a comparison of the constructor itself should be a better option.