### PR TITLE
Fix supportsAudio() so it always return a bool

### DIFF
--- a/src/synth/supports-audio.js
+++ b/src/synth/supports-audio.js
@@ -33,10 +33,10 @@ function supportsAudio() {
 	if (!window.Promise)
 		return false;
 
-	return window.AudioContext ||
-		window.webkitAudioContext ||
-		navigator.mozAudioContext ||
-		navigator.msAudioContext;
+	return !!window.AudioContext ||
+		!!window.webkitAudioContext ||
+		!!navigator.mozAudioContext ||
+		!!navigator.msAudioContext;
 }
 
 module.exports = supportsAudio;


### PR DESCRIPTION
As defined will return window.AudioContext which is an anonymous function