### PR TITLE
add the highlighter to the clickListener param

### DIFF
--- a/src/edit/abc_editor.js
+++ b/src/edit/abc_editor.js
@@ -238,6 +238,8 @@ var Editor = function(editarea, params) {
   	this.selectionChangeCallback = params.selectionChangeCallback;
   }
 
+  this.abcjsParams.clickListener = this.highlight.bind(this);
+
   if (params.synth) {
   	if (supportsAudio()) {
 	    this.synth = {
@@ -338,7 +340,6 @@ Editor.prototype.modelChanged = function() {
   this.tunes = renderAbc(this.div, this.currentAbc, this.abcjsParams);
   if (this.tunes.length > 0) {
 	  this.warnings = this.tunes[0].warnings;
-	  this.tunes[0].engraver.addSelectListener(this.highlight.bind(this));
   }
 	this.redrawMidi();
 


### PR DESCRIPTION
Add the EditArea highlighter to the clickListener now that the editor has access to the renderer params,
This allows any line to be clicked when the `oneSvgPerLine` option is set and still allows the relevant text to be selected,
It currently leaves the previous selected line still highlighted but I'm unsure of the best way to go through each SVG and reset the color yet.
So effectively if there are 4 lines of music one note or element can be selected on each line.