### PR TITLE
Refactor

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,11 @@
 {
   "presets": [
-	"@babel/preset-env"
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "usage",
+        "corejs": 3
+      }
+    ]
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
 tmp/*
 /node_modules
+/lib

--- a/basic.js
+++ b/basic.js
@@ -1,0 +1,52 @@
+var version = require('./version');
+var animation = require('./src/api/abc_animation');
+var tuneBook = require('./src/api/abc_tunebook');
+
+var abcjs = {};
+
+abcjs.signature = "abcjs-basic v" + version;
+
+Object.keys(animation).forEach(function (key) {
+	abcjs[key] = animation[key];
+});
+
+Object.keys(tuneBook).forEach(function (key) {
+	abcjs[key] = tuneBook[key];
+});
+
+abcjs.renderAbc = require('./src/api/abc_tunebook_svg');
+abcjs.TimingCallbacks = require('./src/api/abc_timing_callbacks');
+
+var glyphs = require('./src/write/abc_glyphs');
+abcjs.setGlyph = glyphs.setSymbol;
+
+var CreateSynth = require('./src/synth/create-synth');
+var instrumentIndexToName = require('./src/synth/instrument-index-to-name');
+var pitchToNoteName = require('./src/synth/pitch-to-note-name');
+var SynthSequence = require('./src/synth/synth-sequence');
+var CreateSynthControl = require('./src/synth/create-synth-control');
+var registerAudioContext = require('./src/synth/register-audio-context');
+var activeAudioContext = require('./src/synth/active-audio-context');
+var supportsAudio = require('./src/synth/supports-audio');
+var playEvent = require('./src/synth/play-event');
+var SynthController = require('./src/synth/synth-controller');
+var getMidiFile = require('./src/synth/get-midi-file');
+
+abcjs.synth = {
+	CreateSynth: CreateSynth,
+	instrumentIndexToName: instrumentIndexToName,
+	pitchToNoteName: pitchToNoteName,
+	SynthController: SynthController,
+	SynthSequence: SynthSequence,
+	CreateSynthControl: CreateSynthControl,
+	registerAudioContext: registerAudioContext,
+	activeAudioContext: activeAudioContext,
+	supportsAudio: supportsAudio,
+	playEvent: playEvent,
+	getMidiFile: getMidiFile,
+};
+
+abcjs['Editor'] = require('./src/edit/abc_editor');
+abcjs['EditArea'] = require('./src/edit/abc_editarea');
+
+module.exports = abcjs;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var version = require('./version');
-var animation = require('./src/api/abc_animation');
-var tuneBook = require('./src/api/abc_tunebook');
+var animation = require('./lib/api/abc_animation');
+var tuneBook = require('./lib/api/abc_tunebook');
 
 var abcjs = {};
 
@@ -14,23 +14,23 @@ Object.keys(tuneBook).forEach(function (key) {
 	abcjs[key] = tuneBook[key];
 });
 
-abcjs.renderAbc = require('./src/api/abc_tunebook_svg');
-abcjs.TimingCallbacks = require('./src/api/abc_timing_callbacks');
+abcjs.renderAbc = require('./lib/api/abc_tunebook_svg');
+abcjs.TimingCallbacks = require('./lib/api/abc_timing_callbacks');
 
-var glyphs = require('./src/write/abc_glyphs');
+var glyphs = require('./lib/write/abc_glyphs');
 abcjs.setGlyph = glyphs.setSymbol;
 
-var CreateSynth = require('./src/synth/create-synth');
-var instrumentIndexToName = require('./src/synth/instrument-index-to-name');
-var pitchToNoteName = require('./src/synth/pitch-to-note-name');
-var SynthSequence = require('./src/synth/synth-sequence');
-var CreateSynthControl = require('./src/synth/create-synth-control');
-var registerAudioContext = require('./src/synth/register-audio-context');
-var activeAudioContext = require('./src/synth/active-audio-context');
-var supportsAudio = require('./src/synth/supports-audio');
-var playEvent = require('./src/synth/play-event');
-var SynthController = require('./src/synth/synth-controller');
-var getMidiFile = require('./src/synth/get-midi-file');
+var CreateSynth = require('./lib/synth/create-synth');
+var instrumentIndexToName = require('./lib/synth/instrument-index-to-name');
+var pitchToNoteName = require('./lib/synth/pitch-to-note-name');
+var SynthSequence = require('./lib/synth/synth-sequence');
+var CreateSynthControl = require('./lib/synth/create-synth-control');
+var registerAudioContext = require('./lib/synth/register-audio-context');
+var activeAudioContext = require('./lib/synth/active-audio-context');
+var supportsAudio = require('./lib/synth/supports-audio');
+var playEvent = require('./lib/synth/play-event');
+var SynthController = require('./lib/synth/synth-controller');
+var getMidiFile = require('./lib/synth/get-midi-file');
 
 abcjs.synth = {
 	CreateSynth: CreateSynth,
@@ -46,7 +46,7 @@ abcjs.synth = {
 	getMidiFile: getMidiFile,
 };
 
-abcjs['Editor'] = require('./src/edit/abc_editor');
-abcjs['EditArea'] = require('./src/edit/abc_editarea');
+abcjs['Editor'] = require('./lib/edit/abc_editor');
+abcjs['EditArea'] = require('./lib/edit/abc_editarea');
 
 module.exports = abcjs;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,34 @@
 {
   "name": "abcjs",
-  "version": "6.0.0-beta.11",
+  "version": "6.0.0-beta.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.10.4.tgz",
+      "integrity": "sha512-xX99K4V1BzGJdQANK5cwK+EpF1vP9gvqhn+iWvG+TubCjecplW7RSQimJ2jcCvu6fnK5pY6mZMdu6EWTj32QVA==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.1.8",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "lodash": "^4.17.13",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -2215,15 +2240,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
-    },
-    "abcjs": {
-      "version": "6.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/abcjs/-/abcjs-6.0.0-beta.11.tgz",
-      "integrity": "sha512-P3DE5cZevbCaW4ncg1RDA/Q490yq+wrbxpFH26tUvNPYtLtYY0ujmzDTw8xwgJ7a5AwwCyJ5tZasWS2ES5kKPQ==",
-      "requires": {
-        "abcjs": "6.0.0-beta.11",
-        "midi": "git+https://github.com/paulrosen/MIDI.js.git#abcjs"
-      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -5615,6 +5631,12 @@
       "requires": {
         "minipass": "^3.0.0"
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.0.0-beta.12",
   "description": "Renderer for abc music notation",
   "main": "index.js",
+  "module": "basic.js",
   "scripts": {
     "webpack": "webpack",
     "build": "npm run fix-versions && npm run build:es5 && npm run build:basic-min && npm run build:basic && npm run build:midi && npm run build:plugin && npm run build:plugin-midi",
@@ -45,6 +46,7 @@
     "@vuepress/shared-utils": "1.5.0",
     "babel-loader": "8.1.0",
     "compression-webpack-plugin": "4.0.0",
+    "core-js": "^3.6.5",
     "serialize-javascript": "3.1.0",
     "svg-inline-loader": "0.8.2",
     "vuepress": "1.5.0",
@@ -58,5 +60,6 @@
   "dependencies": {
     "abcjs": "6.0.0-beta.12",
     "midi": "https://github.com/paulrosen/MIDI.js.git#abcjs"
-  }
+  },
+  "browserslist": "defaults"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "webpack": "webpack",
-    "build": "npm run fix-versions && npm run build:basic-min && npm run build:basic && npm run build:midi && npm run build:plugin && npm run build:plugin-midi",
+    "build": "npm run fix-versions && npm run build:es5 && npm run build:basic-min && npm run build:basic && npm run build:midi && npm run build:plugin && npm run build:plugin-midi",
+    "build:es5": "babel src -d lib",
     "build:basic": "npm run webpack -- --env.mode development --env.type basic",
     "build:basic-min": "npm run webpack -- --env.mode production --env.type basic",
     "build:midi": "npm run webpack -- --env.mode production --env.type midi",
@@ -38,6 +39,7 @@
   },
   "homepage": "https://abcjs.net",
   "devDependencies": {
+    "@babel/cli": "^7.10.4",
     "@babel/core": "7.10.2",
     "@babel/preset-env": "7.10.2",
     "@vuepress/shared-utils": "1.5.0",

--- a/src/api/abc_tunebook.js
+++ b/src/api/abc_tunebook.js
@@ -19,7 +19,7 @@
 
 var parseCommon = require('../parse/abc_common');
 var Parse = require('../parse/abc_parse');
-var BookParser = require('../parse/abc_book_parser');
+import BookParser from '../parse/abc_book_parser';
 
 var tunebook = {};
 

--- a/src/api/abc_tunebook.js
+++ b/src/api/abc_tunebook.js
@@ -34,7 +34,9 @@ var tunebook = {};
 	};
 
 	var TuneBook = tunebook.TuneBook = function(book) {
-    this.tunes = BookParser(book)
+    var parsed = BookParser(book)
+    this.header = parsed.header
+    this.tunes = parsed.tunes
 	};
 
 	TuneBook.prototype.getTuneById = function(id) {

--- a/src/api/abc_tunebook.js
+++ b/src/api/abc_tunebook.js
@@ -19,7 +19,7 @@
 
 var parseCommon = require('../parse/abc_common');
 var Parse = require('../parse/abc_parse');
-import BookParser from '../parse/abc_book_parser';
+var BookParser = require('../parse/abc_book_parser');
 
 var tunebook = {};
 

--- a/src/api/abc_tunebook.js
+++ b/src/api/abc_tunebook.js
@@ -19,6 +19,7 @@
 
 var parseCommon = require('../parse/abc_common');
 var Parse = require('../parse/abc_parse');
+var BookParser = require('../parse/abc_book_parser');
 
 var tunebook = {};
 
@@ -33,52 +34,7 @@ var tunebook = {};
 	};
 
 	var TuneBook = tunebook.TuneBook = function(book) {
-		var This = this;
-		var directives = "";
-		book = parseCommon.strip(book);
-		var tunes = book.split("\nX:");
-		for (var i = 1; i < tunes.length; i++)	// Put back the X: that we lost when splitting the tunes.
-			tunes[i] = "X:" + tunes[i];
-		// Keep track of the character position each tune starts with.
-		var pos = 0;
-		This.tunes = [];
-		parseCommon.each(tunes, function(tune) {
-			This.tunes.push({ abc: tune, startPos: pos});
-			pos += tune.length + 1; // We also lost a newline when splitting, so count that.
-		});
-		if (This.tunes.length > 1 && !parseCommon.startsWith(This.tunes[0].abc, 'X:')) {	// If there is only one tune, the X: might be missing, otherwise assume the top of the file is "intertune"
-			// There could be file-wide directives in this, if so, we need to insert it into each tune. We can probably get away with
-			// just looking for file-wide directives here (before the first tune) and inserting them at the bottom of each tune, since
-			// the tune is parsed all at once. The directives will be seen before the engraver begins processing.
-			var dir = This.tunes.shift();
-			var arrDir = dir.abc.split('\n');
-			parseCommon.each(arrDir, function(line) {
-				if (parseCommon.startsWith(line, '%%'))
-					directives += line + '\n';
-			});
-		}
-		This.header = directives;
-
-		// Now, the tune ends at a blank line, so truncate it if needed. There may be "intertune" stuff.
-		parseCommon.each(This.tunes, function(tune) {
-			var end = tune.abc.indexOf('\n\n');
-			if (end > 0)
-				tune.abc = tune.abc.substring(0, end);
-			tune.pure = tune.abc;
-			tune.abc = directives + tune.abc;
-
-			// for the user's convenience, parse and store the title separately. The title is between the first T: and the next \n
-			var title = tune.pure.split("T:");
-			if (title.length > 1) {
-				title = title[1].split("\n");
-				tune.title = title[0].replace(/^\s+|\s+$/g, '');
-			} else
-				tune.title = "";
-
-			// for the user's convenience, parse and store the id separately. The id is between the first X: and the next \n
-			var id = tune.pure.substring(2, tune.pure.indexOf("\n"));
-			tune.id = id.replace(/^\s+|\s+$/g, '');
-		});
+    BookParser.bind(this)(book)
 	};
 
 	TuneBook.prototype.getTuneById = function(id) {

--- a/src/api/abc_tunebook.js
+++ b/src/api/abc_tunebook.js
@@ -19,7 +19,7 @@
 
 var parseCommon = require('../parse/abc_common');
 var Parse = require('../parse/abc_parse');
-var BookParser = require('../parse/abc_book_parser');
+var BookParser = require('../parse/abc_book_parser').default;
 
 var tunebook = {};
 

--- a/src/api/abc_tunebook.js
+++ b/src/api/abc_tunebook.js
@@ -34,7 +34,7 @@ var tunebook = {};
 	};
 
 	var TuneBook = tunebook.TuneBook = function(book) {
-    BookParser.bind(this)(book)
+    this.tunes = BookParser(book)
 	};
 
 	TuneBook.prototype.getTuneById = function(id) {

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -46,7 +46,7 @@ const BookParser = function(book) {
         directives += line + '\n';
     });
   }
-  header = directives;
+  var header = directives;
 
   // Now, the tune ends at a blank line, so truncate it if needed. There may be "intertune" stuff.
   tunes.forEach(function(tune) {
@@ -66,7 +66,7 @@ const BookParser = function(book) {
     var id = tune.pure.substring(2, tune.pure.indexOf("\n"));
     tune.id = id.replace(/^\s+|\s+$/g, '');
   });
-  return tunes;
+  return { header, tunes };
 };
 
 export default BookParser

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -14,39 +14,37 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var parseCommon = require('./abc_common');
-
 var BookParser = function(book) {
 	"use strict";
 
   var This = this;
   var directives = "";
-  book = parseCommon.strip(book);
+  book = book.trim();
   var tunes = book.split("\nX:");
   for (var i = 1; i < tunes.length; i++)	// Put back the X: that we lost when splitting the tunes.
     tunes[i] = "X:" + tunes[i];
   // Keep track of the character position each tune starts with.
   var pos = 0;
   This.tunes = [];
-  parseCommon.each(tunes, function(tune) {
+  tunes.forEach(function(tune) {
     This.tunes.push({ abc: tune, startPos: pos});
     pos += tune.length + 1; // We also lost a newline when splitting, so count that.
   });
-  if (This.tunes.length > 1 && !parseCommon.startsWith(This.tunes[0].abc, 'X:')) {	// If there is only one tune, the X: might be missing, otherwise assume the top of the file is "intertune"
+  if (This.tunes.length > 1 && !This.tunes[0].abc.startsWith('X:')) {	// If there is only one tune, the X: might be missing, otherwise assume the top of the file is "intertune"
     // There could be file-wide directives in this, if so, we need to insert it into each tune. We can probably get away with
     // just looking for file-wide directives here (before the first tune) and inserting them at the bottom of each tune, since
     // the tune is parsed all at once. The directives will be seen before the engraver begins processing.
     var dir = This.tunes.shift();
     var arrDir = dir.abc.split('\n');
-    parseCommon.each(arrDir, function(line) {
-      if (parseCommon.startsWith(line, '%%'))
+    arrDir.forEach(function(line) {
+      if (line.startsWith('%%'))
         directives += line + '\n';
     });
   }
   This.header = directives;
 
   // Now, the tune ends at a blank line, so truncate it if needed. There may be "intertune" stuff.
-  parseCommon.each(This.tunes, function(tune) {
+  This.tunes.forEach(function(tune) {
     var end = tune.abc.indexOf('\n\n');
     if (end > 0)
       tune.abc = tune.abc.substring(0, end);

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -65,6 +65,7 @@ var BookParser = function(book) {
     var id = tune.pure.substring(2, tune.pure.indexOf("\n"));
     tune.id = id.replace(/^\s+|\s+$/g, '');
   });
+  return This.tunes;
 };
 
 module.exports = BookParser

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -50,7 +50,7 @@ const BookParser = function(book) {
 
   // Now, the tune ends at a blank line, so truncate it if needed. There may be "intertune" stuff.
   tunes.forEach(function(tune) {
-    tune.abc = tune.abc.trimEnd() + "\n";
+    tune.abc = tune.abc.trimEnd();
     tune.pure = tune.abc;
     tune.abc = directives + tune.abc;
 

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -50,7 +50,7 @@ const BookParser = function(book) {
 
   // Now, the tune ends at a blank line, so truncate it if needed. There may be "intertune" stuff.
   tunes.forEach(function(tune) {
-    tune.abc = tune.abc.trimEnd();
+    tune.abc = tune.abc.trimEnd() + "\n";
     tune.pure = tune.abc;
     tune.abc = directives + tune.abc;
 

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -20,13 +20,13 @@ var BookParser = function(book) {
   var This = this;
   var directives = "";
   book = book.trim();
-  var tunes = book.split("\nX:");
-  for (var i = 1; i < tunes.length; i++)	// Put back the X: that we lost when splitting the tunes.
-    tunes[i] = "X:" + tunes[i];
+  var tuneStrings = book.split("\nX:");
+  for (var i = 1; i < tuneStrings.length; i++)	// Put back the X: that we lost when splitting the tunes.
+    tuneStrings[i] = "X:" + tuneStrings[i];
   // Keep track of the character position each tune starts with.
   var pos = 0;
   This.tunes = [];
-  tunes.forEach(function(tune) {
+  tuneStrings.forEach(function(tune) {
     This.tunes.push({ abc: tune, startPos: pos});
     pos += tune.length + 1; // We also lost a newline when splitting, so count that.
   });

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -14,6 +14,12 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+/**
+ * BookParser takes a string of abc tunes and returns an array of tunes ready to be passed to the
+ * TuneParser.
+ * A book is split by the 'X:' header and we extract the title and tune id to make tunes easir to
+ * find later.
+ */
 const BookParser = function(book) {
 
   var directives = "";

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -14,7 +14,7 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var BookParser = function(book) {
+const BookParser = function(book) {
 
   var directives = "";
   book = book.trim();
@@ -63,4 +63,4 @@ var BookParser = function(book) {
   return tunes;
 };
 
-module.exports = BookParser
+export default BookParser

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -15,7 +15,6 @@
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var BookParser = function(book) {
-	"use strict";
 
   var directives = "";
   book = book.trim();

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -17,7 +17,6 @@
 var BookParser = function(book) {
 	"use strict";
 
-  var This = this;
   var directives = "";
   book = book.trim();
   var tuneStrings = book.split("\nX:");
@@ -25,26 +24,26 @@ var BookParser = function(book) {
     tuneStrings[i] = "X:" + tuneStrings[i];
   // Keep track of the character position each tune starts with.
   var pos = 0;
-  This.tunes = [];
+  var tunes = [];
   tuneStrings.forEach(function(tune) {
-    This.tunes.push({ abc: tune, startPos: pos});
+    tunes.push({ abc: tune, startPos: pos});
     pos += tune.length + 1; // We also lost a newline when splitting, so count that.
   });
-  if (This.tunes.length > 1 && !This.tunes[0].abc.startsWith('X:')) {	// If there is only one tune, the X: might be missing, otherwise assume the top of the file is "intertune"
+  if (tunes.length > 1 && !tunes[0].abc.startsWith('X:')) {	// If there is only one tune, the X: might be missing, otherwise assume the top of the file is "intertune"
     // There could be file-wide directives in this, if so, we need to insert it into each tune. We can probably get away with
     // just looking for file-wide directives here (before the first tune) and inserting them at the bottom of each tune, since
     // the tune is parsed all at once. The directives will be seen before the engraver begins processing.
-    var dir = This.tunes.shift();
+    var dir = tunes.shift();
     var arrDir = dir.abc.split('\n');
     arrDir.forEach(function(line) {
       if (line.startsWith('%%'))
         directives += line + '\n';
     });
   }
-  This.header = directives;
+  header = directives;
 
   // Now, the tune ends at a blank line, so truncate it if needed. There may be "intertune" stuff.
-  This.tunes.forEach(function(tune) {
+  tunes.forEach(function(tune) {
     var end = tune.abc.indexOf('\n\n');
     if (end > 0)
       tune.abc = tune.abc.substring(0, end);
@@ -63,7 +62,7 @@ var BookParser = function(book) {
     var id = tune.pure.substring(2, tune.pure.indexOf("\n"));
     tune.id = id.replace(/^\s+|\s+$/g, '');
   });
-  return This.tunes;
+  return tunes;
 };
 
 module.exports = BookParser

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -59,12 +59,12 @@ const BookParser = function(book) {
     var title = tune.pure.split("T:");
     if (title.length > 1) {
       title = title[1].split("\n");
-      tune.title = title[0].replace(/^\s+|\s+$/g, '');
+      tune.title = title[0].trim();
     }
 
     // for the user's convenience, parse and store the id separately. The id is between the first X: and the next \n
     var id = tune.pure.substring(2, tune.pure.indexOf("\n"));
-    tune.id = id.replace(/^\s+|\s+$/g, '');
+    tune.id = id.trim();
   });
   return { header, tunes };
 };

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -50,7 +50,9 @@ const BookParser = function(book) {
 
   // Now, the tune ends at a blank line, so truncate it if needed. There may be "intertune" stuff.
   tunes.forEach(function(tune) {
-    tune.abc = tune.abc.trimEnd();
+    var end = tune.abc.indexOf('\n\n');
+    if (end > 0)
+      tune.abc = tune.abc.substring(0, end);
     tune.pure = tune.abc;
     tune.abc = directives + tune.abc;
 

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -1,0 +1,70 @@
+//    abc_parse.js: parses a string representing ABC Music Notation into a usable internal structure.
+//    Copyright (C) 2010-2020 Paul Rosen (paul at paulrosen dot net)
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+//    documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+//    the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+//    to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+//    BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var parseCommon = require('./abc_common');
+
+var BookParser = function(book) {
+	"use strict";
+
+  var This = this;
+  var directives = "";
+  book = parseCommon.strip(book);
+  var tunes = book.split("\nX:");
+  for (var i = 1; i < tunes.length; i++)	// Put back the X: that we lost when splitting the tunes.
+    tunes[i] = "X:" + tunes[i];
+  // Keep track of the character position each tune starts with.
+  var pos = 0;
+  This.tunes = [];
+  parseCommon.each(tunes, function(tune) {
+    This.tunes.push({ abc: tune, startPos: pos});
+    pos += tune.length + 1; // We also lost a newline when splitting, so count that.
+  });
+  if (This.tunes.length > 1 && !parseCommon.startsWith(This.tunes[0].abc, 'X:')) {	// If there is only one tune, the X: might be missing, otherwise assume the top of the file is "intertune"
+    // There could be file-wide directives in this, if so, we need to insert it into each tune. We can probably get away with
+    // just looking for file-wide directives here (before the first tune) and inserting them at the bottom of each tune, since
+    // the tune is parsed all at once. The directives will be seen before the engraver begins processing.
+    var dir = This.tunes.shift();
+    var arrDir = dir.abc.split('\n');
+    parseCommon.each(arrDir, function(line) {
+      if (parseCommon.startsWith(line, '%%'))
+        directives += line + '\n';
+    });
+  }
+  This.header = directives;
+
+  // Now, the tune ends at a blank line, so truncate it if needed. There may be "intertune" stuff.
+  parseCommon.each(This.tunes, function(tune) {
+    var end = tune.abc.indexOf('\n\n');
+    if (end > 0)
+      tune.abc = tune.abc.substring(0, end);
+    tune.pure = tune.abc;
+    tune.abc = directives + tune.abc;
+
+    // for the user's convenience, parse and store the title separately. The title is between the first T: and the next \n
+    var title = tune.pure.split("T:");
+    if (title.length > 1) {
+      title = title[1].split("\n");
+      tune.title = title[0].replace(/^\s+|\s+$/g, '');
+    } else
+      tune.title = "";
+
+    // for the user's convenience, parse and store the id separately. The id is between the first X: and the next \n
+    var id = tune.pure.substring(2, tune.pure.indexOf("\n"));
+    tune.id = id.replace(/^\s+|\s+$/g, '');
+  });
+};
+
+module.exports = BookParser

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -50,12 +50,12 @@ var BookParser = function(book) {
     tune.abc = directives + tune.abc;
 
     // for the user's convenience, parse and store the title separately. The title is between the first T: and the next \n
+    tune.title = "";
     var title = tune.pure.split("T:");
     if (title.length > 1) {
       title = title[1].split("\n");
       tune.title = title[0].replace(/^\s+|\s+$/g, '');
-    } else
-      tune.title = "";
+    }
 
     // for the user's convenience, parse and store the id separately. The id is between the first X: and the next \n
     var id = tune.pure.substring(2, tune.pure.indexOf("\n"));

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -29,7 +29,8 @@ var BookParser = function(book) {
     tunes.push({ abc: tune, startPos: pos});
     pos += tune.length + 1; // We also lost a newline when splitting, so count that.
   });
-  if (tunes.length > 1 && !tunes[0].abc.startsWith('X:')) {	// If there is only one tune, the X: might be missing, otherwise assume the top of the file is "intertune"
+  if (tunes.length > 1 && !tunes[0].abc.startsWith('X:')) {
+    // If there is only one tune, the X: might be missing, otherwise assume the top of the file is "intertune"
     // There could be file-wide directives in this, if so, we need to insert it into each tune. We can probably get away with
     // just looking for file-wide directives here (before the first tune) and inserting them at the bottom of each tune, since
     // the tune is parsed all at once. The directives will be seen before the engraver begins processing.
@@ -44,9 +45,7 @@ var BookParser = function(book) {
 
   // Now, the tune ends at a blank line, so truncate it if needed. There may be "intertune" stuff.
   tunes.forEach(function(tune) {
-    var end = tune.abc.indexOf('\n\n');
-    if (end > 0)
-      tune.abc = tune.abc.substring(0, end);
+    tune.abc = tune.abc.trimEnd();
     tune.pure = tune.abc;
     tune.abc = directives + tune.abc;
 

--- a/src/parse/abc_book_parser.js
+++ b/src/parse/abc_book_parser.js
@@ -15,9 +15,9 @@
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /**
- * BookParser takes a string of abc tunes and returns an array of tunes ready to be passed to the
- * TuneParser.
- * A book is split by the 'X:' header and we extract the title and tune id to make tunes easir to
+ * BookParser takes a string of abc tunes and returns an object consisting of a header string and
+ * an array of tune objects to later be passed to the tune parser.
+ * A book is split by the 'X:' header and we extract the title and tune id to make tunes easier to
  * find later.
  */
 const BookParser = function(book) {

--- a/static-wrappers/basic.js
+++ b/static-wrappers/basic.js
@@ -1,2 +1,2 @@
 require('./license');
-window.ABCJS = require('../index.js');
+window.ABCJS = require('../basic.js');


### PR DESCRIPTION
Had a little trouble getting this going but I feel like this seems to be a good standard for at least slowly pushing everyhting to ES6.
The main troubles were from mixing an ES6 import with an ES5 `modules.export` at the bottom. seems like web[ack doesnt support this as far as I can tell.
I've tried to tidy up the function a little removing calls to ParseCommon which ES6 now provides mainly `string.prototype.startsWith` and `endsWith`. removing some regex functions for `trim`. This removes the dependency of `ParseComon` 
