### PR TITLE
use Es6 import syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,44 @@
-var version = require('./version');
-var animation = require('./src/api/abc_animation');
-var tuneBook = require('./src/api/abc_tunebook');
+import version from './version'
+import animation from './src/api/abc_animation'
+import tuneBook from './src/api/abc_tunebook'
+import renderAbc from './src/api/abc_tunebook_svg'
+import TimingCallbacks from './src/api/abc_timing_callbacks'
+import Editor from './src/edit/abc_editor'
+import EditArea from './src/edit/abc_editarea'
+import glyphs from './src/write/abc_glyphs'
+import CreateSynth from './src/synth/create-synth'
+import instrumentIndexToName from './src/synth/instrument-index-to-name'
+import pitchToNoteName from './src/synth/pitch-to-note-name'
+import SynthSequence from './src/synth/synth-sequence'
+import CreateSynthControl from './src/synth/create-synth-control'
+import registerAudioContext from './src/synth/register-audio-context'
+import activeAudioContext from './src/synth/active-audio-context'
+import supportsAudio from './src/synth/supports-audio'
+import playEvent from './src/synth/play-event'
+import SynthController from './src/synth/synth-controller'
+import getMidiFile from './src/synth/get-midi-file'
 
-var abcjs = {};
-
-abcjs.signature = "abcjs-basic v" + version;
+const abcjs = {
+	signature: "abcjs-basic v" + version,
+	Editor: Editor,
+	EditArea: EditArea,
+	setGlyph: glyphs.setSymbol,
+	renderAbc: renderAbc,
+	TimingCallbacks: TimingCallbacks,
+	synth: {
+		CreateSynth: CreateSynth,
+		instrumentIndexToName: instrumentIndexToName,
+		pitchToNoteName: pitchToNoteName,
+		SynthController: SynthController,
+		SynthSequence: SynthSequence,
+		CreateSynthControl: CreateSynthControl,
+		registerAudioContext: registerAudioContext,
+		activeAudioContext: activeAudioContext,
+		supportsAudio: supportsAudio,
+		playEvent: playEvent,
+		getMidiFile: getMidiFile,
+	}
+};
 
 Object.keys(animation).forEach(function (key) {
 	abcjs[key] = animation[key];
@@ -14,39 +48,4 @@ Object.keys(tuneBook).forEach(function (key) {
 	abcjs[key] = tuneBook[key];
 });
 
-abcjs.renderAbc = require('./src/api/abc_tunebook_svg');
-abcjs.TimingCallbacks = require('./src/api/abc_timing_callbacks');
-
-var glyphs = require('./src/write/abc_glyphs');
-abcjs.setGlyph = glyphs.setSymbol;
-
-var CreateSynth = require('./src/synth/create-synth');
-var instrumentIndexToName = require('./src/synth/instrument-index-to-name');
-var pitchToNoteName = require('./src/synth/pitch-to-note-name');
-var SynthSequence = require('./src/synth/synth-sequence');
-var CreateSynthControl = require('./src/synth/create-synth-control');
-var registerAudioContext = require('./src/synth/register-audio-context');
-var activeAudioContext = require('./src/synth/active-audio-context');
-var supportsAudio = require('./src/synth/supports-audio');
-var playEvent = require('./src/synth/play-event');
-var SynthController = require('./src/synth/synth-controller');
-var getMidiFile = require('./src/synth/get-midi-file');
-
-abcjs.synth = {
-	CreateSynth: CreateSynth,
-	instrumentIndexToName: instrumentIndexToName,
-	pitchToNoteName: pitchToNoteName,
-	SynthController: SynthController,
-	SynthSequence: SynthSequence,
-	CreateSynthControl: CreateSynthControl,
-	registerAudioContext: registerAudioContext,
-	activeAudioContext: activeAudioContext,
-	supportsAudio: supportsAudio,
-	playEvent: playEvent,
-	getMidiFile: getMidiFile,
-};
-
-abcjs['Editor'] = require('./src/edit/abc_editor');
-abcjs['EditArea'] = require('./src/edit/abc_editarea');
-
-module.exports = abcjs;
+export default abcjs

--- a/midi.js
+++ b/midi.js
@@ -1,12 +1,13 @@
-var abcjs = require('./index');
-var version = require('./version');
+import abcjs from './index'
+import version from './version'
 
 abcjs.signature = "abcjs-midi v" + version;
 
-abcjs.renderMidi = require('./src/api/abc_tunebook_midi');
+import renderMidi from './src/api/abc_tunebook_midi'
+abcjs.renderMidi = renderMidi
 require("./src/midi/abc_midi_ui_generator");
 
-var midi = require('./src/midi/abc_midi_controls');
+import midi from './src/midi/abc_midi_controls'
 abcjs.midi = {
 	setSoundFont: midi.setSoundFont,
 	startPlaying: midi.startPlaying,
@@ -18,4 +19,4 @@ abcjs.midi = {
 	setInteractiveProgressBar: midi.setInteractiveProgressBar
 };
 
-module.exports = abcjs;
+export default abcjs

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "abcjs",
   "version": "6.0.0-beta.15",
   "description": "Renderer for abc music notation",
-  "main": "index.js",
+  "main": "dist/abcjs-basic.js",
+  "module": "index.js",
   "scripts": {
     "webpack": "webpack",
     "build": "npm run fix-versions && npm run build:basic && npm run build:basic-min && npm run build:midi && npm run build:plugin && npm run build:plugin-midi && npm run build:dist",

--- a/src/api/abc_animation.js
+++ b/src/api/abc_animation.js
@@ -14,7 +14,7 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var TimingCallbacks = require('./abc_timing_callbacks');
+import TimingCallbacks from './abc_timing_callbacks';
 
 var animation = {};
 
@@ -123,4 +123,4 @@ var animation = {};
 
 })();
 
-module.exports = animation;
+export default animation;

--- a/src/api/abc_timing_callbacks.js
+++ b/src/api/abc_timing_callbacks.js
@@ -224,5 +224,5 @@ function getLineEndTimings(timings, anticipation) {
 	return callbackTimes;
 }
 
-module.exports = TimingCallbacks;
+export default TimingCallbacks;
 

--- a/src/api/abc_tunebook.js
+++ b/src/api/abc_tunebook.js
@@ -14,8 +14,8 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var Parse = require('../parse/abc_parse');
-var bookParser = require('../parse/abc_parse_book');
+import Parse from '../parse/abc_parse';
+import bookParser from '../parse/abc_parse_book';
 
 var tunebook = {};
 
@@ -266,4 +266,4 @@ var tunebook = {};
 	};
 })();
 
-module.exports = tunebook;
+export default tunebook;

--- a/src/api/abc_tunebook_midi.js
+++ b/src/api/abc_tunebook_midi.js
@@ -13,10 +13,10 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var tunebook = require('./abc_tunebook');
+import tunebook from './abc_tunebook';
 
-var midi = require('../midi/abc_midi_controls');
-var midiCreate = require('../midi/abc_midi_create');
+import midi from '../midi/abc_midi_controls';
+import midiCreate from '../midi/abc_midi_create';
 
 // A quick way to render a tune from javascript when interactivity is not required.
 // This is used when a javascript routine has some abc text that it wants to render
@@ -113,4 +113,4 @@ var renderMidi = function(output, abc, parserParams, midiParams, renderParams) {
     return tunebook.renderEngine(callback, output, abc, params);
 };
 
-module.exports = renderMidi;
+export default renderMidi;

--- a/src/api/abc_tunebook_svg.js
+++ b/src/api/abc_tunebook_svg.js
@@ -13,14 +13,15 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var tunebook = require('./abc_tunebook');
-var Tune = require('../data/abc_tune');
+import tunebook from './abc_tunebook';
+import Tune from '../data/abc_tune';
 
-var EngraverController = require('../write/abc_engraver_controller');
-var Parse = require('../parse/abc_parse');
-var wrap = require('../parse/wrap_lines');
+import EngraverController from '../write/abc_engraver_controller';
+import Parse from '../parse/abc_parse';
+import wrap from '../parse/wrap_lines';
 
 var resizeDivs = {};
+
 function resizeOuter() {
     var width = window.innerWidth;
     for (var id in resizeDivs) {
@@ -255,4 +256,4 @@ function doLineWrapping(div, tune, tuneNumber, abcString, params) {
 	return ret.tune;
 }
 
-module.exports = renderAbc;
+export default renderAbc;

--- a/src/data/abc_tune.js
+++ b/src/data/abc_tune.js
@@ -14,10 +14,10 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var parseCommon = require('../parse/abc_common');
-var spacing = require('../write/abc_spacing');
-var sequence = require('../synth/abc_midi_sequencer');
-var flatten = require('../synth/abc_midi_flattener');
+import parseCommon from '../parse/abc_common';
+import spacing from '../write/abc_spacing';
+import sequence from '../synth/abc_midi_sequencer';
+import flatten from '../synth/abc_midi_flattener';
 
 /**
  * This is the data for a single ABC tune. It is created and populated by the window.ABCJS.parse.Parse class.
@@ -489,4 +489,4 @@ var Tune = function() {
 	};
 };
 
-module.exports = Tune;
+export default Tune;

--- a/src/edit/abc_editarea.js
+++ b/src/edit/abc_editarea.js
@@ -123,4 +123,4 @@ EditArea.prototype.getElem = function() {
   return this.textarea;
 };
 
-module.exports = EditArea;
+export default EditArea;

--- a/src/edit/abc_editor.js
+++ b/src/edit/abc_editor.js
@@ -45,11 +45,11 @@
 // - pause(bool)
 //		Stops the automatic rendering when the user is typing.
 //
-var parseCommon = require('../parse/abc_common');
-var SynthController = require('../synth/synth-controller');
-var supportsAudio = require('../synth/supports-audio');
-var renderAbc = require('../api/abc_tunebook_svg');
-var EditArea = require('./abc_editarea');
+import parseCommon from '../parse/abc_common';
+import SynthController from '../synth/synth-controller';
+import supportsAudio from '../synth/supports-audio';
+import renderAbc from '../api/abc_tunebook_svg';
+import EditArea from './abc_editarea';
 
 function gatherAbcParams(params) {
 	// There used to be a bunch of ways parameters can be passed in. This just simplifies it.
@@ -374,4 +374,4 @@ Editor.prototype.pauseMidi = function(shouldPause) {
 		this.redrawMidi();
 };
 
-module.exports = Editor;
+export default Editor;

--- a/src/midi/abc_midi_controls.js
+++ b/src/midi/abc_midi_controls.js
@@ -698,4 +698,4 @@ var midi = {};
 
 })();
 
-module.exports = midi;
+export default midi;

--- a/src/midi/abc_midi_create.js
+++ b/src/midi/abc_midi_create.js
@@ -14,8 +14,8 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var Preparer = require('./abc_midi_js_preparer');
-var rendererFactory = require('../synth/abc_midi_renderer');
+import Preparer from './abc_midi_js_preparer';
+import rendererFactory from '../synth/abc_midi_renderer';
 
 var create;
 
@@ -117,4 +117,4 @@ var create;
 
 })();
 
-module.exports = create;
+export default create;

--- a/src/midi/abc_midi_js_preparer.js
+++ b/src/midi/abc_midi_js_preparer.js
@@ -240,4 +240,4 @@ var Preparer;
 	};
 })();
 
-module.exports = Preparer;
+export default Preparer;

--- a/src/midi/abc_midi_ui_generator.js
+++ b/src/midi/abc_midi_ui_generator.js
@@ -14,8 +14,9 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var midi = require('./abc_midi_controls');
-var midiCreate = require('./abc_midi_create');
+import midi from './abc_midi_controls';
+import midiCreate from './abc_midi_create';
+
 var abcMidiUiGenerator;
 
 (function () {
@@ -83,4 +84,4 @@ var abcMidiUiGenerator;
 	});
 })();
 
-module.exports = abcMidiUiGenerator;
+export default abcMidiUiGenerator;

--- a/src/parse/abc_common.js
+++ b/src/parse/abc_common.js
@@ -115,4 +115,4 @@ try {
 } catch(e) {
 	// if we aren't in a browser, this code will crash, but it is not needed then either.
 }
-module.exports = parseCommon;
+export default parseCommon;

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -14,16 +14,16 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var parseCommon = require('./abc_common');
-var parseDirective = require('./abc_parse_directive');
-var ParseHeader = require('./abc_parse_header');
-var parseKeyVoice = require('./abc_parse_key_voice');
-var Tokenizer = require('./abc_tokenizer');
-var transpose = require('./abc_transpose');
-var wrap = require('./wrap_lines');
+import parseCommon from './abc_common';
+import parseDirective from './abc_parse_directive';
+import ParseHeader from './abc_parse_header';
+import parseKeyVoice from './abc_parse_key_voice';
+import Tokenizer from './abc_tokenizer';
+import transpose from './abc_transpose';
+import wrap from './wrap_lines';
 
-var Tune = require('../data/abc_tune');
-var TuneBuilder = require('../parse/tune-builder');
+import Tune from '../data/abc_tune';
+import TuneBuilder from '../parse/tune-builder';
 
 var Parse = function() {
 	"use strict";
@@ -1816,4 +1816,4 @@ var Parse = function() {
 	};
 };
 
-module.exports = Parse;
+export default Parse;

--- a/src/parse/abc_parse_book.js
+++ b/src/parse/abc_parse_book.js
@@ -14,7 +14,7 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var parseCommon = require('./abc_common');
+import parseCommon from './abc_common';
 
 var bookParser = function(book) {
 	"use strict";
@@ -72,5 +72,4 @@ var bookParser = function(book) {
 	};
 };
 
-module.exports = bookParser;
-
+export default bookParser;

--- a/src/parse/abc_parse_directive.js
+++ b/src/parse/abc_parse_directive.js
@@ -13,7 +13,7 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var parseCommon = require('./abc_common');
+import parseCommon from './abc_common';
 
 var parseDirective = {};
 
@@ -1097,4 +1097,4 @@ var parseDirective = {};
 	};
 })();
 
-module.exports = parseDirective;
+export default parseDirective;

--- a/src/parse/abc_parse_header.js
+++ b/src/parse/abc_parse_header.js
@@ -14,9 +14,9 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var parseCommon = require('./abc_common');
-var parseDirective = require('./abc_parse_directive');
-var parseKeyVoice = require('./abc_parse_key_voice');
+import parseCommon from './abc_common';
+import parseDirective from './abc_parse_directive';
+import parseKeyVoice from './abc_parse_key_voice';
 
 var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 	this.reset = function(tokenizer, warn, multilineVars, tune) {
@@ -586,4 +586,4 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 	};
 };
 
-module.exports = ParseHeader;
+export default ParseHeader;

--- a/src/parse/abc_parse_key_voice.js
+++ b/src/parse/abc_parse_key_voice.js
@@ -13,9 +13,9 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var parseCommon = require('./abc_common');
-var parseDirective = require('./abc_parse_directive');
-var transpose = require('./abc_transpose');
+import parseCommon from './abc_common';
+import parseDirective from './abc_parse_directive';
+import transpose from './abc_transpose';
 
 var parseKeyVoice = {};
 
@@ -933,4 +933,4 @@ var parseKeyVoice = {};
 
 })();
 
-module.exports = parseKeyVoice;
+export default parseKeyVoice;

--- a/src/parse/abc_tokenizer.js
+++ b/src/parse/abc_tokenizer.js
@@ -14,7 +14,7 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var parseCommon = require('./abc_common');
+import parseCommon from './abc_common';
 
 // this is a series of functions that get a particular element out of the passed stream.
 // the return is the number of characters consumed, so 0 means that the element wasn't found.
@@ -752,4 +752,4 @@ var Tokenizer = function() {
 	};
 };
 
-module.exports = Tokenizer;
+export default Tokenizer;

--- a/src/parse/abc_transpose.js
+++ b/src/parse/abc_transpose.js
@@ -227,4 +227,4 @@ transpose.note = function(multilineVars, el) {
 
 };
 
-module.exports = transpose;
+export default transpose;

--- a/src/parse/tune-builder.js
+++ b/src/parse/tune-builder.js
@@ -1,5 +1,5 @@
-var parseKeyVoice = require('../parse/abc_parse_key_voice');
-var parseCommon = require('../parse/abc_common');
+import parseKeyVoice from '../parse/abc_parse_key_voice';
+import parseCommon from '../parse/abc_common';
 
 var TuneBuilder = function(tune) {
 	var self = this;
@@ -886,4 +886,4 @@ var TuneBuilder = function(tune) {
 
 };
 
-module.exports = TuneBuilder;
+export default TuneBuilder;

--- a/src/parse/wrap_lines.js
+++ b/src/parse/wrap_lines.js
@@ -687,4 +687,4 @@ function calcLineWraps(tune, widths, abcString, params, Parse, engraver_controll
 	return ret;
 }
 
-module.exports = { wrapLines: wrapLines, calcLineWraps: calcLineWraps };
+export default { wrapLines: wrapLines, calcLineWraps: calcLineWraps };

--- a/src/plugin/abc_plugin.js
+++ b/src/plugin/abc_plugin.js
@@ -18,9 +18,9 @@
 /*global abcjs_is_user_script, abcjs_plugin_autostart */
 "use strict";
 
-var TuneBook = require('../api/abc_tunebook').TuneBook;
-var Parse = require('../parse/abc_parse');
-var EngraverController = require('../write/abc_engraver_controller');
+import {TuneBook} from '../api/abc_tunebook';
+import Parse from '../parse/abc_parse';
+import EngraverController from '../write/abc_engraver_controller';
 
 var Plugin = function() {
 	"use strict";
@@ -239,4 +239,4 @@ if (autostart &&
   }
 }
 
-module.exports = plugin;
+export default plugin;

--- a/src/plugin/abc_plugin_midi.js
+++ b/src/plugin/abc_plugin_midi.js
@@ -17,8 +17,8 @@
 
 /*global abcjs_is_user_script, abcjs_plugin_autostart */
 
-var renderAbc = require('../api/abc_tunebook_svg');
-var renderMidi = require('../api/abc_tunebook_midi');
+import renderAbc from '../api/abc_tunebook_svg';
+import renderMidi from '../api/abc_tunebook_midi';
 
 var Plugin = function() {
 	"use strict";
@@ -217,4 +217,4 @@ if (autostart &&
   }
 }
 
-module.exports = plugin;
+export default plugin;

--- a/src/synth/abc_midi_flattener.js
+++ b/src/synth/abc_midi_flattener.js
@@ -18,8 +18,9 @@
 // of the grace notes, decorations, ties, triplets, rests, transpositions, keys, and accidentals into actual note durations.
 // It also extracts guitar chords to a separate voice and resolves their rhythm.
 
+import parseCommon from "../parse/abc_common";
+
 var flatten;
-var parseCommon = require("../parse/abc_common");
 
 (function() {
 	"use strict";
@@ -1208,4 +1209,4 @@ var parseCommon = require("../parse/abc_common");
 	}
 })();
 
-module.exports = flatten;
+export default flatten;

--- a/src/synth/abc_midi_renderer.js
+++ b/src/synth/abc_midi_renderer.js
@@ -267,4 +267,4 @@ var rendererFactory;
 	};
 })();
 
-module.exports = rendererFactory;
+export default rendererFactory;

--- a/src/synth/abc_midi_sequencer.js
+++ b/src/synth/abc_midi_sequencer.js
@@ -14,8 +14,9 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import parseCommon from "../parse/abc_common";
+
 var sequence;
-var parseCommon = require("../parse/abc_common");
 
 (function() {
 	"use strict";
@@ -550,4 +551,4 @@ var parseCommon = require("../parse/abc_common");
 	}
 })();
 
-module.exports = sequence;
+export default sequence;

--- a/src/synth/active-audio-context.js
+++ b/src/synth/active-audio-context.js
@@ -12,7 +12,8 @@
 //    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-var registerAudioContext = require('./register-audio-context.js');
+
+import registerAudioContext from './register-audio-context.js';
 
 function activeAudioContext() {
 	if (!window.abcjsAudioContext)
@@ -20,4 +21,4 @@ function activeAudioContext() {
 	return window.abcjsAudioContext;
 }
 
-module.exports = activeAudioContext;
+export default activeAudioContext;

--- a/src/synth/create-note-map.js
+++ b/src/synth/create-note-map.js
@@ -15,7 +15,7 @@
 
 // Convert the input structure to a more useful structure where each item has a length of its own.
 
-var instrumentIndexToName = require('./instrument-index-to-name');
+import instrumentIndexToName from './instrument-index-to-name';
 
 var createNoteMap = function(sequence) {
 	var map = [];
@@ -61,4 +61,4 @@ var createNoteMap = function(sequence) {
 	return map;
 };
 
-module.exports = createNoteMap;
+export default createNoteMap;

--- a/src/synth/create-synth-control.js
+++ b/src/synth/create-synth-control.js
@@ -13,10 +13,10 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var supportsAudio = require('./supports-audio');
-var registerAudioContext = require('./register-audio-context');
-var activeAudioContext = require('./active-audio-context');
-var parseCommon = require('../parse/abc_common');
+import supportsAudio from './supports-audio';
+import registerAudioContext from './register-audio-context';
+import activeAudioContext from './active-audio-context';
+import parseCommon from '../parse/abc_common';
 // TODO-PER: The require statements for svg don't play well for node apps without extra plugins. The following lines would be clearer than inlining the SVG
 // var loopImage = require('./images/loop.svg');
 // var playImage = require('./images/play.svg');
@@ -307,4 +307,4 @@ function attachListeners(self) {
 	if (hasWarp)
 		self.parent.querySelector(".abcjs-midi-tempo").addEventListener("change", function(ev){acResumerMiddleWare(self.options.warpHandler, ev, playBtn, self.options.afterResume)});
 }
-module.exports = CreateSynthControl;
+export default CreateSynthControl;

--- a/src/synth/create-synth.js
+++ b/src/synth/create-synth.js
@@ -13,15 +13,15 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var getNote = require('./load-note');
-var createNoteMap = require('./create-note-map');
-var registerAudioContext = require('./register-audio-context');
-var activeAudioContext = require('./active-audio-context');
-var supportsAudio = require('./supports-audio');
-var pitchToNoteName = require('./pitch-to-note-name');
-var instrumentIndexToName = require('./instrument-index-to-name');
-var downloadBuffer = require('./download-buffer');
-var placeNote = require('./place-note');
+import getNote from './load-note';
+import createNoteMap from './create-note-map';
+import registerAudioContext from './register-audio-context';
+import activeAudioContext from './active-audio-context';
+import supportsAudio from './supports-audio';
+import pitchToNoteName from './pitch-to-note-name';
+import instrumentIndexToName from './instrument-index-to-name';
+import downloadBuffer from './download-buffer';
+import placeNote from './place-note';
 
 // TODO-PER: remove the midi tests from here: I don't think the object can be constructed unless it passes.
 var notSupportedMessage = "MIDI is not supported in this browser.";
@@ -389,4 +389,4 @@ function CreateSynth() {
 	};
 }
 
-module.exports = CreateSynth;
+export default CreateSynth;

--- a/src/synth/download-buffer.js
+++ b/src/synth/download-buffer.js
@@ -74,4 +74,4 @@ function bufferToWave(audioBuffers) {
 	}
 }
 
-module.exports = downloadBuffer;
+export default downloadBuffer;

--- a/src/synth/get-midi-file.js
+++ b/src/synth/get-midi-file.js
@@ -13,8 +13,8 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var tunebook = require('../api/abc_tunebook');
-var midiCreate = require('../midi/abc_midi_create');
+import tunebook from '../api/abc_tunebook';
+import midiCreate from '../midi/abc_midi_create';
 
 var getMidiFile = function(abcString, options) {
 	var params = {};
@@ -81,5 +81,4 @@ var generateMidiDownloadLink = function(tune, midiParams, midi, index) {
 	return html + "</div>";
 };
 
-
-module.exports = getMidiFile;
+export default getMidiFile;

--- a/src/synth/instrument-index-to-name.js
+++ b/src/synth/instrument-index-to-name.js
@@ -161,4 +161,4 @@ var instrumentIndexToName = [
 	"percussion"
 ];
 
-module.exports = instrumentIndexToName;
+export default instrumentIndexToName;

--- a/src/synth/load-note.js
+++ b/src/synth/load-note.js
@@ -17,7 +17,7 @@
 // url = the base url for the soundfont
 // instrument = the instrument name (e.g. "acoustic_grand_piano")
 // name = the pitch name (e.g. "A3")
-var soundsCache = require('./sounds-cache');
+import soundsCache from './sounds-cache';
 
 var getNote = function(url, instrument, name, audioContext) {
 	return new Promise(function (resolve, reject) {
@@ -80,4 +80,4 @@ var getNote = function(url, instrument, name, audioContext) {
 	});
 };
 
-module.exports = getNote;
+export default getNote;

--- a/src/synth/pitch-to-note-name.js
+++ b/src/synth/pitch-to-note-name.js
@@ -117,4 +117,4 @@ var pitchToNoteName = {
 	121: 'Db9'
 };
 
-module.exports = pitchToNoteName;
+export default pitchToNoteName;

--- a/src/synth/place-note.js
+++ b/src/synth/place-note.js
@@ -13,8 +13,8 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var soundsCache = require('./sounds-cache');
-var pitchToNoteName = require('./pitch-to-note-name');
+import soundsCache from './sounds-cache';
+import pitchToNoteName from './pitch-to-note-name';
 
 function placeNote(outputAudioBuffer, sampleRate, sound, startArray) {
 	// sound contains { instrument, pitch, volume, len, pan, tempoMultiplier
@@ -95,4 +95,4 @@ var copyToChannel = function(toBuffer, fromBuffer, start) {
 	}
 };
 
-module.exports = placeNote;
+export default placeNote;

--- a/src/synth/play-event.js
+++ b/src/synth/play-event.js
@@ -13,8 +13,8 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var SynthSequence = require('./synth-sequence');
-var CreateSynth = require('./create-synth');
+import SynthSequence from './synth-sequence';
+import CreateSynth from './create-synth';
 
 function playEvent(midiPitches, midiGracePitches, millisecondsPerMeasure) {
 	var sequence = new SynthSequence();
@@ -42,4 +42,5 @@ function playEvent(midiPitches, midiGracePitches, millisecondsPerMeasure) {
 		return buffer.start();
 	});
 }
-module.exports = playEvent;
+
+export default playEvent;

--- a/src/synth/register-audio-context.js
+++ b/src/synth/register-audio-context.js
@@ -31,4 +31,4 @@ function registerAudioContext(ac) {
 	return window.abcjsAudioContext.state !== "suspended";
 }
 
-module.exports = registerAudioContext;
+export default registerAudioContext;

--- a/src/synth/sounds-cache.js
+++ b/src/synth/sounds-cache.js
@@ -16,4 +16,4 @@
 var soundsCache = {
 };
 
-module.exports = soundsCache;
+export default soundsCache;

--- a/src/synth/supports-audio.js
+++ b/src/synth/supports-audio.js
@@ -13,7 +13,7 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var activeAudioContext = require('./active-audio-context');
+import activeAudioContext from './active-audio-context';
 
 //
 // Support for audio depends on three things: support for Promise, support for AudioContext, and support for AudioContext.resume.
@@ -39,4 +39,4 @@ function supportsAudio() {
 		!!navigator.msAudioContext;
 }
 
-module.exports = supportsAudio;
+export default supportsAudio;

--- a/src/synth/synth-controller.js
+++ b/src/synth/synth-controller.js
@@ -13,10 +13,10 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var CreateSynthControl = require('./create-synth-control');
-var CreateSynth = require('./create-synth');
-var TimingCallbacks = require('../api/abc_timing_callbacks');
-var activeAudioContext = require('./active-audio-context');
+import CreateSynthControl from './create-synth-control';
+import CreateSynth from './create-synth';
+import TimingCallbacks from '../api/abc_timing_callbacks';
+import activeAudioContext from './active-audio-context';
 
 function SynthController() {
 	var self = this;
@@ -278,4 +278,4 @@ function SynthController() {
 	};
 }
 
-module.exports = SynthController;
+export default SynthController;

--- a/src/synth/synth-sequence.js
+++ b/src/synth/synth-sequence.js
@@ -54,4 +54,4 @@ var SynthSequence = function() {
 	};
 };
 
-module.exports = SynthSequence;
+export default SynthSequence;

--- a/src/test/abc_midi_lint.js
+++ b/src/test/abc_midi_lint.js
@@ -50,4 +50,4 @@ var midiLint = function(tune) {
 	return ret;
 };
 
-module.exports = midiLint;
+export default midiLint;

--- a/src/test/abc_midi_sequencer_lint.js
+++ b/src/test/abc_midi_sequencer_lint.js
@@ -163,4 +163,4 @@ var midiSequencerLint = function(tune) {
 	return ret;
 };
 
-module.exports = midiSequencerLint;
+export default midiSequencerLint;

--- a/src/test/abc_parser_lint.js
+++ b/src/test/abc_parser_lint.js
@@ -62,8 +62,8 @@
 // Expanded:
 // MIDI is now { cmd, param }
 
-var parseCommon = require('../parse/abc_common');
-var JSONSchema = require('./jsonschema-b4');
+import parseCommon from '../parse/abc_common';
+import JSONSchema from './jsonschema-b4';
 
 var ParserLint = function() {
 	"use strict";
@@ -652,4 +652,4 @@ var ParserLint = function() {
 	};
 };
 
-module.exports = ParserLint;
+export default ParserLint;

--- a/src/test/abc_vertical_lint.js
+++ b/src/test/abc_vertical_lint.js
@@ -468,4 +468,4 @@ var verticalLint = function(tunes) {
 	return positioning;
 };
 
-module.exports = verticalLint;
+export default verticalLint;

--- a/src/test/jsonschema-b4.js
+++ b/src/test/jsonschema-b4.js
@@ -300,4 +300,4 @@ var JSONSchema = {
 */
 };
 
-module.exports = JSONSchema;
+export default JSONSchema;

--- a/src/test/rendering-lint.js
+++ b/src/test/rendering-lint.js
@@ -290,4 +290,4 @@ function listArrayOfObjects(key, arr, indent) {
 	return output.join("\n"+tab);
 }
 
-module.exports = renderingLint;
+export default renderingLint;

--- a/src/write/abc_absolute_element.js
+++ b/src/write/abc_absolute_element.js
@@ -14,7 +14,7 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var setClass = require('./set-class');
+import setClass from './set-class';
 
 // duration - actual musical duration - different from notehead duration in triplets. refer to abcelem to get the notehead duration
 // minspacing - spacing which must be taken on top of the width defined by the duration
@@ -159,4 +159,4 @@ AbsoluteElement.prototype.unhighlight = function (klass, color) {
 	setClass(this.elemset, "", klass, color);
 };
 
-module.exports = AbsoluteElement;
+export default AbsoluteElement;

--- a/src/write/abc_abstract_engraver.js
+++ b/src/write/abc_abstract_engraver.js
@@ -14,25 +14,25 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var AbsoluteElement = require('./abc_absolute_element');
-var BeamElem = require('./abc_beam_element');
-var BraceElem = require('./abc_brace_element');
-var createClef = require('./abc_create_clef');
-var createKeySignature = require('./abc_create_key_signature');
-var createTimeSignature = require('./abc_create_time_signature');
-var Decoration = require('./abc_decoration');
-var EndingElem = require('./abc_ending_element');
-var glyphs = require('./abc_glyphs');
-var RelativeElement = require('./abc_relative_element');
-var spacing = require('./abc_spacing');
-var StaffGroupElement = require('./abc_staff_group_element');
-var TempoElement = require('./abc_tempo_element');
-var TieElem = require('./abc_tie_element');
-var TripletElem = require('./abc_triplet_element');
-var VoiceElement = require('./abc_voice_element');
-var addChord = require('./add-chord');
+import AbsoluteElement from './abc_absolute_element';
+import BeamElem from './abc_beam_element';
+import BraceElem from './abc_brace_element';
+import createClef from './abc_create_clef';
+import createKeySignature from './abc_create_key_signature';
+import createTimeSignature from './abc_create_time_signature';
+import Decoration from './abc_decoration';
+import EndingElem from './abc_ending_element';
+import glyphs from './abc_glyphs';
+import RelativeElement from './abc_relative_element';
+import spacing from './abc_spacing';
+import StaffGroupElement from './abc_staff_group_element';
+import TempoElement from './abc_tempo_element';
+import TieElem from './abc_tie_element';
+import TripletElem from './abc_triplet_element';
+import VoiceElement from './abc_voice_element';
+import addChord from './add-chord';
 
-var parseCommon = require('../parse/abc_common');
+import parseCommon from '../parse/abc_common';
 
 var AbstractEngraver;
 
@@ -1092,4 +1092,4 @@ AbstractEngraver.prototype.createBarLine = function (voice, elem, isFirstStaff) 
 
 })();
 
-module.exports = AbstractEngraver;
+export default AbstractEngraver;

--- a/src/write/abc_beam_element.js
+++ b/src/write/abc_beam_element.js
@@ -103,4 +103,4 @@ function calcAverage(total, numElements) {
 	return total / numElements;
 }
 
-module.exports = BeamElem;
+export default BeamElem;

--- a/src/write/abc_brace_element.js
+++ b/src/write/abc_brace_element.js
@@ -43,4 +43,4 @@ BraceElem.prototype.isStartVoice = function (voice) {
 	return false;
 };
 
-module.exports = BraceElem;
+export default BraceElem;

--- a/src/write/abc_create_clef.js
+++ b/src/write/abc_create_clef.js
@@ -14,9 +14,9 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var AbsoluteElement = require('./abc_absolute_element');
-var glyphs = require('./abc_glyphs');
-var RelativeElement = require('./abc_relative_element');
+import AbsoluteElement from './abc_absolute_element';
+import glyphs from './abc_glyphs';
+import RelativeElement from './abc_relative_element';
 
 var createClef;
 
@@ -81,4 +81,4 @@ var createClef;
 
 })();
 
-module.exports = createClef;
+export default createClef;

--- a/src/write/abc_create_key_signature.js
+++ b/src/write/abc_create_key_signature.js
@@ -14,11 +14,11 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var AbsoluteElement = require('./abc_absolute_element');
-var glyphs = require('./abc_glyphs');
-var RelativeElement = require('./abc_relative_element');
+import AbsoluteElement from './abc_absolute_element';
+import glyphs from './abc_glyphs';
+import RelativeElement from './abc_relative_element';
 
-var parseCommon = require('../parse/abc_common');
+import parseCommon from '../parse/abc_common';
 
 var createKeySignature;
 
@@ -49,4 +49,4 @@ var createKeySignature;
 	};
 })();
 
-module.exports = createKeySignature;
+export default createKeySignature;

--- a/src/write/abc_create_time_signature.js
+++ b/src/write/abc_create_time_signature.js
@@ -14,9 +14,9 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var AbsoluteElement = require('./abc_absolute_element');
-var glyphs = require('./abc_glyphs');
-var RelativeElement = require('./abc_relative_element');
+import AbsoluteElement from './abc_absolute_element';
+import glyphs from './abc_glyphs';
+import RelativeElement from './abc_relative_element';
 
 var createTimeSignature;
 
@@ -72,4 +72,4 @@ var createTimeSignature;
 	};
 })();
 
-module.exports = createTimeSignature;
+export default createTimeSignature;

--- a/src/write/abc_crescendo_element.js
+++ b/src/write/abc_crescendo_element.js
@@ -26,4 +26,4 @@ var CrescendoElem = function CrescendoElem(anchor1, anchor2, dir, positioning) {
 	this.pitch = undefined; // This will be set later
 };
 
-module.exports = CrescendoElem;
+export default CrescendoElem;

--- a/src/write/abc_decoration.js
+++ b/src/write/abc_decoration.js
@@ -14,11 +14,11 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var DynamicDecoration = require('./abc_dynamic_decoration');
-var CrescendoElem = require('./abc_crescendo_element');
-var glyphs = require('./abc_glyphs');
-var RelativeElement = require('./abc_relative_element');
-var TieElem = require('./abc_tie_element');
+import DynamicDecoration from './abc_dynamic_decoration';
+import CrescendoElem from './abc_crescendo_element';
+import glyphs from './abc_glyphs';
+import RelativeElement from './abc_relative_element';
+import TieElem from './abc_tie_element';
 
 var Decoration;
 
@@ -346,4 +346,4 @@ var Decoration;
 
 })();
 
-module.exports = Decoration;
+export default Decoration;

--- a/src/write/abc_dynamic_decoration.js
+++ b/src/write/abc_dynamic_decoration.js
@@ -25,4 +25,4 @@ var DynamicDecoration = function DynamicDecoration(anchor, dec, position) {
 	this.pitch = undefined; // This will be set later
 };
 
-module.exports = DynamicDecoration;
+export default DynamicDecoration;

--- a/src/write/abc_ending_element.js
+++ b/src/write/abc_ending_element.js
@@ -23,4 +23,4 @@ var EndingElem = function EndingElem(text, anchor1, anchor2) {
 	this.pitch = undefined; // This will be set later
 };
 
-module.exports = EndingElem;
+export default EndingElem;

--- a/src/write/abc_engraver_controller.js
+++ b/src/write/abc_engraver_controller.js
@@ -17,21 +17,21 @@
 
 /*global Math */
 
-var spacing = require('./abc_spacing');
-var AbstractEngraver = require('./abc_abstract_engraver');
-var Renderer = require('./abc_renderer');
-var FreeText = require('./free-text');
-var Separator = require('./separator');
-var Subtitle = require('./subtitle');
-var TopText = require('./top-text');
-var BottomText = require('./bottom-text');
-var setupSelection = require('./selection');
-var layout = require('./layout/layout');
-var Classes = require('./classes');
-var GetFontAndAttr = require('./get-font-and-attr');
-var GetTextSize = require('./get-text-size');
-var draw = require('./draw/draw');
-var calcHeight = require('./layout/calcHeight');
+import spacing from './abc_spacing';
+import AbstractEngraver from './abc_abstract_engraver';
+import Renderer from './abc_renderer';
+import FreeText from './free-text';
+import Separator from './separator';
+import Subtitle from './subtitle';
+import TopText from './top-text';
+import BottomText from './bottom-text';
+import setupSelection from './selection';
+import layout from './layout/layout';
+import Classes from './classes';
+import GetFontAndAttr from './get-font-and-attr';
+import GetTextSize from './get-text-size';
+import draw from './draw/draw';
+import calcHeight from './layout/calcHeight';
 
 /**
  * @class
@@ -250,4 +250,4 @@ EngraverController.prototype.addSelectListener = function (clickListener) {
 	this.listeners[this.listeners.length] = clickListener;
 };
 
-module.exports = EngraverController;
+export default EngraverController;

--- a/src/write/abc_glyphs.js
+++ b/src/write/abc_glyphs.js
@@ -13,7 +13,7 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var spacing = require('./abc_spacing');
+import spacing from './abc_spacing';
 
 /**
  * Glyphs and some methods to adjust for their x and y baseline
@@ -231,4 +231,4 @@ var Glyphs = {
 	}
 };
 
-module.exports = Glyphs; // we need the glyphs for layout information
+export default Glyphs; // we need the glyphs for layout information

--- a/src/write/abc_relative_element.js
+++ b/src/write/abc_relative_element.js
@@ -78,4 +78,4 @@ RelativeElement.prototype.setX = function (x) {
 	this.x = x+this.dx;
 };
 
-module.exports = RelativeElement;
+export default RelativeElement;

--- a/src/write/abc_renderer.js
+++ b/src/write/abc_renderer.js
@@ -16,9 +16,9 @@
 
 /*global Math */
 
-var spacing = require('./abc_spacing');
-var Svg = require('./svg');
-var AbsoluteElement = require('./abc_absolute_element');
+import spacing from './abc_spacing';
+import Svg from './svg';
+import AbsoluteElement from './abc_absolute_element';
 
 /**
  * Implements the API for rendering ABCJS Abstract Rendering Structure to a canvas/paper (e.g. SVG, Raphael, etc)
@@ -200,4 +200,4 @@ Renderer.prototype.moveY = function (em, numLines) {
 	this.y += em*numLines;
 };
 
-module.exports = Renderer;
+export default Renderer;

--- a/src/write/abc_spacing.js
+++ b/src/write/abc_spacing.js
@@ -23,4 +23,4 @@ spacing.TOPNOTE = 15;
 spacing.STAVEHEIGHT = 100;
 spacing.INDENT = 50;
 
-module.exports = spacing;
+export default spacing;

--- a/src/write/abc_staff_group_element.js
+++ b/src/write/abc_staff_group_element.js
@@ -104,4 +104,4 @@ StaffGroupElement.prototype.setStaffLimits = function (voice) {
 	this.setLimit('dynamicHeightBelow', voice);
 };
 
-module.exports = StaffGroupElement;
+export default StaffGroupElement;

--- a/src/write/abc_tempo_element.js
+++ b/src/write/abc_tempo_element.js
@@ -14,8 +14,8 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var AbsoluteElement = require('./abc_absolute_element');
-var RelativeElement = require('./abc_relative_element');
+import AbsoluteElement from './abc_absolute_element';
+import RelativeElement from './abc_relative_element';
 
 var TempoElement;
 (function() {
@@ -90,4 +90,4 @@ var TempoElement;
 	};
 })();
 
-module.exports = TempoElement;
+export default TempoElement;

--- a/src/write/abc_tie_element.js
+++ b/src/write/abc_tie_element.js
@@ -197,4 +197,4 @@ TieElem.prototype.avoidCollisionAbove = function () {
 	}
 };
 
-module.exports = TieElem;
+export default TieElem;

--- a/src/write/abc_triplet_element.js
+++ b/src/write/abc_triplet_element.js
@@ -46,4 +46,4 @@ var TripletElem;
 
 })();
 
-module.exports = TripletElem;
+export default TripletElem;

--- a/src/write/abc_voice_element.js
+++ b/src/write/abc_voice_element.js
@@ -100,4 +100,4 @@ VoiceElement.prototype.addBeam = function (child) {
 	this.beams.push(child);
 };
 
-module.exports = VoiceElement;
+export default VoiceElement;

--- a/src/write/add-chord.js
+++ b/src/write/add-chord.js
@@ -1,5 +1,5 @@
-var RelativeElement = require('./abc_relative_element');
-var spacing = require('./abc_spacing');
+import RelativeElement from './abc_relative_element';
+import spacing from './abc_spacing';
 
 var addChord;
 
@@ -89,4 +89,4 @@ var addChord;
 
 })();
 
-module.exports = addChord;
+export default addChord;

--- a/src/write/bottom-text.js
+++ b/src/write/bottom-text.js
@@ -92,4 +92,4 @@ BottomText.prototype.addTextIf = function (marginLeft, text, font, klass, margin
 		this.rows.push({move: marginBottom});
 }
 
-module.exports = BottomText;
+export default BottomText;

--- a/src/write/classes.js
+++ b/src/write/classes.js
@@ -74,4 +74,4 @@ Classes.prototype.generate = function (c) {
 };
 
 
-module.exports = Classes;
+export default Classes;

--- a/src/write/draw/absolute.js
+++ b/src/write/draw/absolute.js
@@ -1,8 +1,8 @@
-var drawTempo = require('./tempo');
-var drawRelativeElement = require('./relative');
-var spacing = require('../abc_spacing');
-var setClass = require('../set-class');
-var elementGroup = require('./group-elements');
+import drawTempo from './tempo';
+import drawRelativeElement from './relative';
+import spacing from '../abc_spacing';
+import setClass from '../set-class';
+import elementGroup from './group-elements';
 
 function drawAbsolute(renderer, params, bartop, selectables) {
 	if (params.invisible) return;
@@ -58,4 +58,4 @@ function drawAbsolute(renderer, params, bartop, selectables) {
 	var step = spacing.STEP;
 }
 
-module.exports = drawAbsolute;
+export default drawAbsolute;

--- a/src/write/draw/beam.js
+++ b/src/write/draw/beam.js
@@ -1,4 +1,4 @@
-var printPath = require('./print-path');
+import printPath from './print-path';
 
 function drawBeam(renderer, params) {
 	if (params.beams.length === 0) return;
@@ -54,4 +54,4 @@ function getY(startX, startY, slope, currentX) {
 	return startY + x*slope;
 }
 
-module.exports = drawBeam;
+export default drawBeam;

--- a/src/write/draw/brace.js
+++ b/src/write/draw/brace.js
@@ -1,6 +1,6 @@
-var sprintf = require('./sprintf');
-var spacing = require('../abc_spacing');
-var renderText = require('./text');
+import sprintf from './sprintf';
+import spacing from '../abc_spacing';
+import renderText from './text';
 
 function drawBrace(renderer, params, selectables) {
 	// The absoluteY number is the spot where the note on the first ledger line is drawn (i.e. middle C if treble clef)
@@ -105,4 +105,5 @@ var draw = function (renderer, xLeft, yTop, yBottom, type, header, selectables) 
 
 	return ret;
 };
-module.exports = drawBrace;
+
+export default drawBrace;

--- a/src/write/draw/crescendo.js
+++ b/src/write/draw/crescendo.js
@@ -1,7 +1,7 @@
-var highlight = require('../highlight');
-var unhighlight = require('../unhighlight');
-var sprintf = require('./sprintf');
-var printPath = require('./print-path');
+import highlight from '../highlight';
+import unhighlight from '../unhighlight';
+import sprintf from './sprintf';
+import printPath from './print-path';
 
 function drawCrescendo(renderer, params, selectables) {
 	if (params.pitch === undefined)
@@ -30,4 +30,4 @@ var drawLine = function (renderer, y1, y2, y3, y4, left, right) {
 	return el;
 };
 
-module.exports = drawCrescendo;
+export default drawCrescendo;

--- a/src/write/draw/debug-box.js
+++ b/src/write/draw/debug-box.js
@@ -5,4 +5,4 @@ function printDebugBox(renderer, attr, comment) {
 	return box;
 }
 
-module.exports = printDebugBox;
+export default printDebugBox;

--- a/src/write/draw/draw.js
+++ b/src/write/draw/draw.js
@@ -1,8 +1,8 @@
-var drawStaffGroup = require('./staff-group');
-var setPaperSize = require('./set-paper-size');
-var nonMusic = require('./non-music');
-var spacing = require('../abc_spacing');
-var Selectables = require('./selectables');
+import drawStaffGroup from './staff-group';
+import setPaperSize from './set-paper-size';
+import nonMusic from './non-music';
+import spacing from '../abc_spacing';
+import Selectables from './selectables';
 
 function draw(renderer, classes, abcTune, width, maxWidth, responsive, scale, selectTypes, tuneNumber) {
 	var selectables = new Selectables(renderer.paper, selectTypes, tuneNumber);
@@ -50,4 +50,4 @@ function addStaffPadding(renderer, staffSeparation, lastStaffGroup, thisStaffGro
 		renderer.moveY(staffSeparation-separationInPixels);
 }
 
-module.exports = draw;
+export default draw;

--- a/src/write/draw/dynamics.js
+++ b/src/write/draw/dynamics.js
@@ -1,4 +1,4 @@
-var printSymbol = require('./print-symbol');
+import printSymbol from './print-symbol';
 
 function drawDynamics(renderer, params, selectables) {
 	if (params.pitch === undefined)
@@ -10,4 +10,4 @@ function drawDynamics(renderer, params, selectables) {
 	return [el];
 }
 
-module.exports = drawDynamics;
+export default drawDynamics;

--- a/src/write/draw/ending.js
+++ b/src/write/draw/ending.js
@@ -1,6 +1,6 @@
-var sprintf = require('./sprintf');
-var renderText = require('./text');
-var printPath = require('./print-path');
+import sprintf from './sprintf';
+import renderText from './text';
+import printPath from './print-path';
 
 function drawEnding(renderer, params, linestartx, lineendx, selectables) {
 	if (params.pitch === undefined)
@@ -41,4 +41,4 @@ function drawEnding(renderer, params, linestartx, lineendx, selectables) {
 	return [g];
 }
 
-module.exports = drawEnding;
+export default drawEnding;

--- a/src/write/draw/group-elements.js
+++ b/src/write/draw/group-elements.js
@@ -65,4 +65,4 @@ var elementGroup;
 	elementGroup = new Group();
 })();
 
-module.exports = elementGroup;
+export default elementGroup;

--- a/src/write/draw/horizontal-line.js
+++ b/src/write/draw/horizontal-line.js
@@ -20,4 +20,4 @@ function printHorizontalLine(renderer, width, vertical, comment) {
 		renderer.paper.text(comment, {x: width+70, y: y, "text-anchor": "start", "font-size":"18px", fill: fill, stroke: fill });
 }
 
-module.exports = printHorizontalLine;
+export default printHorizontalLine;

--- a/src/write/draw/non-music.js
+++ b/src/write/draw/non-music.js
@@ -1,5 +1,5 @@
-var drawSeparator = require('./separator');
-var renderText = require('./text');
+import drawSeparator from './separator';
+import renderText from './text';
 
 function nonMusic(renderer, obj, selectables) {
 	for (var i = 0; i < obj.rows.length; i++) {
@@ -42,4 +42,4 @@ function nonMusic(renderer, obj, selectables) {
 	}
 }
 
-module.exports = nonMusic;
+export default nonMusic;

--- a/src/write/draw/print-path.js
+++ b/src/write/draw/print-path.js
@@ -4,4 +4,4 @@ function printPath(renderer, attrs, params) {
 	return ret;
 }
 
-module.exports = printPath;
+export default printPath;

--- a/src/write/draw/print-stem.js
+++ b/src/write/draw/print-stem.js
@@ -1,4 +1,4 @@
-var elementGroup = require('./group-elements');
+import elementGroup from './group-elements';
 
 function printStem(renderer, x, dx, y1, y2) {
 	if (dx<0 || y1<y2) { // correct path "handedness" for intersection with other elements
@@ -26,4 +26,4 @@ function printStem(renderer, x, dx, y1, y2) {
 	}
 }
 
-module.exports = printStem;
+export default printStem;

--- a/src/write/draw/print-symbol.js
+++ b/src/write/draw/print-symbol.js
@@ -1,6 +1,6 @@
-var renderText = require('./text');
-var glyphs = require('../abc_glyphs');
-var elementGroup = require('./group-elements');
+import renderText from './text';
+import glyphs from '../abc_glyphs';
+import elementGroup from './group-elements';
 
 /**
  * assumes this.y is set appropriately
@@ -54,4 +54,4 @@ function kernSymbols(lastSymbol, thisSymbol, lastSymbolWidth) {
 	return width;
 }
 
-module.exports = printSymbol;
+export default printSymbol;

--- a/src/write/draw/print-vertical-line.js
+++ b/src/write/draw/print-vertical-line.js
@@ -13,4 +13,4 @@ function printVerticalLine (renderer, x, y1, y2) {
 
 }
 
-module.exports = printVerticalLine;
+export default printVerticalLine;

--- a/src/write/draw/relative.js
+++ b/src/write/draw/relative.js
@@ -1,7 +1,7 @@
-var renderText = require('./text');
-var printStem = require('./print-stem');
-var printStaffLine = require('./staff-line');
-var printSymbol = require('./print-symbol');
+import renderText from './text';
+import printStem from './print-stem';
+import printStaffLine from './staff-line';
+import printSymbol from './print-symbol';
 
 function drawRelativeElement(renderer, params, bartop, selectables) {
 	if (params.pitch === undefined)
@@ -53,4 +53,4 @@ function scaleExistingElem(paper, elem, scaleX, scaleY, x, y) {
 	paper.setAttributeOnElement(elem, { style: "transform:scale("+scaleX+","+scaleY + ");transform-origin:" + x + "px " + y + "px;"});
 }
 
-module.exports = drawRelativeElement;
+export default drawRelativeElement;

--- a/src/write/draw/selectables.js
+++ b/src/write/draw/selectables.js
@@ -1,5 +1,5 @@
-var highlight = require('../highlight');
-var unhighlight = require('../unhighlight');
+import highlight from '../highlight';
+import unhighlight from '../unhighlight';
 
 function Selectables(paper, selectTypes, tuneNumber) {
 	this.elements = [];
@@ -45,4 +45,4 @@ Selectables.prototype.wrapSvgEl = function(abcelem, el) {
 	this.add(absEl, el, false);
 };
 
-module.exports = Selectables;
+export default Selectables;

--- a/src/write/draw/separator.js
+++ b/src/write/draw/separator.js
@@ -13,4 +13,4 @@ function drawSeparator(renderer, width) {
 	renderer.paper.pathToBack({path:pathString, stroke:stroke, fill:fill, 'class': renderer.controller.classes.generate('defined-text')});
 }
 
-module.exports = drawSeparator;
+export default drawSeparator;

--- a/src/write/draw/set-paper-size.js
+++ b/src/write/draw/set-paper-size.js
@@ -38,4 +38,4 @@ function setPaperSize(renderer, maxwidth, scale, responsive) {
 	renderer.paper.setParentStyles(parentStyles);
 }
 
-module.exports = setPaperSize;
+export default setPaperSize;

--- a/src/write/draw/sprintf.js
+++ b/src/write/draw/sprintf.js
@@ -62,4 +62,4 @@ var sprintf = function() {
   return o.join('');
 };
 
-module.exports = sprintf;
+export default sprintf;

--- a/src/write/draw/staff-group.js
+++ b/src/write/draw/staff-group.js
@@ -1,9 +1,9 @@
-var spacing = require('../abc_spacing');
-var drawBrace = require('./brace');
-var drawVoice = require('./voice');
-var printStaff = require('./staff');
-var printDebugBox = require('./debug-box');
-var printStem = require('./print-stem');
+import spacing from '../abc_spacing';
+import drawBrace from './brace';
+import drawVoice from './voice';
+import printStaff from './staff';
+import printDebugBox from './debug-box';
+import printStem from './print-stem';
 
 function drawStaffGroup(renderer, params, selectables) {
 	// We enter this method with renderer.y pointing to the topmost coordinate that we're allowed to draw.
@@ -158,4 +158,4 @@ function boxAllElements(renderer, voices) {
 	}
 }
 
-module.exports = drawStaffGroup;
+export default drawStaffGroup;

--- a/src/write/draw/staff-line.js
+++ b/src/write/draw/staff-line.js
@@ -1,4 +1,4 @@
-var sprintf = require('./sprintf');
+import sprintf from './sprintf';
 
 function printStaffLine(renderer, x1,x2, pitch, klass) {
 	var isIE=/*@cc_on!@*/false;//IE detector
@@ -19,5 +19,4 @@ function printStaffLine(renderer, x1,x2, pitch, klass) {
 	return ret;
 }
 
-module.exports = printStaffLine;
-
+export default printStaffLine;

--- a/src/write/draw/staff.js
+++ b/src/write/draw/staff.js
@@ -1,4 +1,4 @@
-var printStaffLine = require('./staff-line');
+import printStaffLine from './staff-line';
 
 function printStaff(renderer, startx, endx, numLines) {
 	var klass = "abcjs-top-line";
@@ -15,4 +15,4 @@ function printStaff(renderer, startx, endx, numLines) {
 	renderer.paper.closeGroup();
 }
 
-module.exports = printStaff;
+export default printStaff;

--- a/src/write/draw/tempo.js
+++ b/src/write/draw/tempo.js
@@ -1,5 +1,5 @@
-var drawRelativeElement = require('./relative');
-var renderText = require('./text');
+import drawRelativeElement from './relative';
+import renderText from './text';
 
 function drawTempo(renderer, params, selectables) {
 	var x = params.x;
@@ -40,4 +40,4 @@ function drawTempo(renderer, params, selectables) {
 	return [tempoGroup];
 }
 
-module.exports = drawTempo;
+export default drawTempo;

--- a/src/write/draw/text.js
+++ b/src/write/draw/text.js
@@ -51,4 +51,4 @@ function renderText(renderer, params) {
 	return elem;
 }
 
-module.exports = renderText;
+export default renderText;

--- a/src/write/draw/tie.js
+++ b/src/write/draw/tie.js
@@ -1,4 +1,4 @@
-var sprintf = require('./sprintf');
+import sprintf from './sprintf';
 
 function drawTie(renderer, params, linestartx, lineendx, selectables) {
 	layout(params, linestartx, lineendx);
@@ -76,4 +76,4 @@ var drawArc = function(renderer, x1, x2, pitch1, pitch2, above, klass, isTie) {
 	return ret;
 };
 
-module.exports = drawTie;
+export default drawTie;

--- a/src/write/draw/triplet.js
+++ b/src/write/draw/triplet.js
@@ -1,6 +1,6 @@
-var sprintf = require('./sprintf');
-var renderText = require('./text');
-var printPath = require('./print-path');
+import sprintf from './sprintf';
+import renderText from './text';
+import printPath from './print-path';
 
 function drawTriplet(renderer, params, selectables) {
 	var xTextPos;
@@ -42,4 +42,4 @@ function drawBracket(renderer, x1, y1, x2, y2) {
 	printPath(renderer, {path: pathString, stroke: "#000000"});
 }
 
-module.exports = drawTriplet;
+export default drawTriplet;

--- a/src/write/draw/voice.js
+++ b/src/write/draw/voice.js
@@ -1,11 +1,11 @@
-var drawCrescendo = require('./crescendo');
-var drawDynamics = require('./dynamics');
-var drawTriplet = require('./triplet');
-var drawEnding = require('./ending');
-var drawTie = require('./tie');
-var drawBeam = require('./beam');
-var renderText = require('./text');
-var drawAbsolute = require('./absolute');
+import drawCrescendo from './crescendo';
+import drawDynamics from './dynamics';
+import drawTriplet from './triplet';
+import drawEnding from './ending';
+import drawTie from './tie';
+import drawBeam from './beam';
+import renderText from './text';
+import drawAbsolute from './absolute';
 
 function drawVoice(renderer, params, bartop, selectables) {
 	var width = params.w-1;
@@ -88,4 +88,4 @@ function isNonSpacerRest(elem) {
 	return false;
 }
 
-module.exports = drawVoice;
+export default drawVoice;

--- a/src/write/free-text.js
+++ b/src/write/free-text.js
@@ -30,4 +30,4 @@ function FreeText(text, vskip, getFontAndAttr, paddingLeft, width, getTextSize) 
 	}
 }
 
-module.exports = FreeText;
+export default FreeText;

--- a/src/write/get-font-and-attr.js
+++ b/src/write/get-font-and-attr.js
@@ -34,4 +34,4 @@ GetFontAndAttr.prototype.calc = function(type, klass) {
 	return { font: font, attr: attr };
 };
 
-module.exports = GetFontAndAttr;
+export default GetFontAndAttr;

--- a/src/write/get-text-size.js
+++ b/src/write/get-text-size.js
@@ -52,5 +52,4 @@ GetTextSize.prototype.baselineToCenter = function(text, type, klass, index, tota
 	return height * 0.5 + (total - index - 2) * fontHeight;
 };
 
-
-module.exports = GetTextSize;
+export default GetTextSize;

--- a/src/write/highlight.js
+++ b/src/write/highlight.js
@@ -1,4 +1,4 @@
-var setClass = require('./set-class');
+import setClass from './set-class';
 
 var highlight = function (klass, color) {
 	if (klass === undefined)
@@ -8,4 +8,4 @@ var highlight = function (klass, color) {
 	setClass(this.elemset, klass, "", color);
 };
 
-module.exports = highlight;
+export default highlight;

--- a/src/write/layout/VoiceElements.js
+++ b/src/write/layout/VoiceElements.js
@@ -84,4 +84,4 @@ function getMinWidth(child) { // absolute space taken to the right of the note
 	return child.w;
 };
 
-module.exports = VoiceElement;
+export default VoiceElement;

--- a/src/write/layout/beam.js
+++ b/src/write/layout/beam.js
@@ -1,6 +1,6 @@
-var RelativeElement = require('../abc_relative_element');
-var spacing = require('../abc_spacing');
-var getBarYAt = require('./getBarYAt');
+import RelativeElement from '../abc_relative_element';
+import spacing from '../abc_spacing';
+import getBarYAt from './getBarYAt';
 
 var layoutBeam = function(beam) {
 	if (beam.elems.length === 0 || beam.allrests) return;
@@ -208,4 +208,4 @@ function createAdditionalBeams(elems, asc, beam, isGrace, dy) {
 	return beams;
 }
 
-module.exports = layoutBeam;
+export default layoutBeam;

--- a/src/write/layout/calcHeight.js
+++ b/src/write/layout/calcHeight.js
@@ -13,5 +13,4 @@ var calcHeight = function (staffGroup) {
 	return height;
 };
 
-module.exports = calcHeight;
-
+export default calcHeight;

--- a/src/write/layout/getBarYAt.js
+++ b/src/write/layout/getBarYAt.js
@@ -2,5 +2,5 @@ function getBarYAt(startx, starty, endx, endy, x) {
 	return starty + (endy - starty) / (endx - startx) * (x - startx);
 }
 
-module.exports = getBarYAt;
+export default getBarYAt;
 

--- a/src/write/layout/layout.js
+++ b/src/write/layout/layout.js
@@ -1,7 +1,7 @@
-var calcHeight = require('./calcHeight');
-var layoutVoice = require('./voice');
-var setUpperAndLowerElements = require('./setUpperAndLowerElements');
-var layoutStaffGroup = require('./staffGroup');
+import calcHeight from './calcHeight';
+import layoutVoice from './voice';
+import setUpperAndLowerElements from './setUpperAndLowerElements';
+import layoutStaffGroup from './staffGroup';
 var layout;
 
 (function () {
@@ -91,4 +91,4 @@ var layout;
 	}
 })();
 
-module.exports = layout;
+export default layout;

--- a/src/write/layout/setUpperAndLowerElements.js
+++ b/src/write/layout/setUpperAndLowerElements.js
@@ -1,4 +1,4 @@
-var spacing = require('../abc_spacing');
+import spacing from '../abc_spacing';
 
 var setUpperAndLowerElements = function(renderer, staffGroup) {
 	// Each staff already has the top and bottom set, now we see if there are elements that are always on top and bottom, and resolve their pitch.
@@ -206,4 +206,4 @@ function setUpperAndLowerRelativeElements(positionY, element) {
 		console.error("RelativeElement position not set.", element.type, element.pitch, element.top, positionY);
 }
 
-module.exports = setUpperAndLowerElements;
+export default setUpperAndLowerElements;

--- a/src/write/layout/staffGroup.js
+++ b/src/write/layout/staffGroup.js
@@ -1,4 +1,4 @@
-var layoutVoiceElements = require('./VoiceElements');
+import layoutVoiceElements from './VoiceElements';
 
 var layoutStaffGroup = function(spacing, renderer, debug, staffGroup) {
 	var epsilon = 0.0000001; // Fudging for inexactness of floating point math.
@@ -164,4 +164,4 @@ function getDurationIndex(element) {
 	return element.durationindex - (element.children[element.i] && (element.children[element.i].duration>0)?0:0.0000005); // if the ith element doesn't have a duration (is not a note), its duration index is fractionally before. This enables CLEF KEYSIG TIMESIG PART, etc. to be laid out before we get to the first note of other voices
 };
 
-module.exports = layoutStaffGroup;
+export default layoutStaffGroup;

--- a/src/write/layout/voice.js
+++ b/src/write/layout/voice.js
@@ -1,5 +1,5 @@
-var layoutBeam = require('./beam');
-var getBarYAt = require('./getBarYAt');
+import layoutBeam from './beam';
+import getBarYAt from './getBarYAt';
 
 var layoutVoice = function(voice) {
 	for (var i = 0; i < voice.beams.length; i++) {
@@ -124,4 +124,4 @@ function xAtMidpoint(startX, endX) {
 	return startX + (endX - startX)/2;
 };
 
-module.exports = layoutVoice;
+export default layoutVoice;

--- a/src/write/selection.js
+++ b/src/write/selection.js
@@ -13,7 +13,7 @@
 //    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var spacing = require('./abc_spacing');
+import spacing from './abc_spacing';
 
 function setupSelection(engraver) {
 	engraver.rangeHighlight = rangeHighlight;
@@ -393,4 +393,4 @@ function removeGlobalClass(svg, klass) {
 	}
 }
 
-module.exports = setupSelection;
+export default setupSelection;

--- a/src/write/separator.js
+++ b/src/write/separator.js
@@ -7,4 +7,4 @@ function Separator(spaceAbove, lineLength, spaceBelow) {
 		this.rows.push({move: spaceBelow});
 }
 
-module.exports = Separator;
+export default Separator;

--- a/src/write/set-class.js
+++ b/src/write/set-class.js
@@ -18,4 +18,4 @@ var setClass = function (elemset, addClass, removeClass, color) {
 	}
 };
 
-module.exports = setClass;
+export default setClass;

--- a/src/write/subtitle.js
+++ b/src/write/subtitle.js
@@ -7,4 +7,4 @@ function Subtitle(spaceAbove, text, center, getTextSize) {
 	this.rows.push({move: size.height});
 }
 
-module.exports = Subtitle;
+export default Subtitle;

--- a/src/write/svg.js
+++ b/src/write/svg.js
@@ -365,5 +365,4 @@ function createSvg() {
 	return svg;
 }
 
-
-module.exports = Svg;
+export default Svg;

--- a/src/write/top-text.js
+++ b/src/write/top-text.js
@@ -55,4 +55,4 @@ TopText.prototype.addTextIf = function (marginLeft, text, font, klass, marginTop
 	}
 }
 
-module.exports = TopText;
+export default TopText;

--- a/src/write/unhighlight.js
+++ b/src/write/unhighlight.js
@@ -1,4 +1,4 @@
-var setClass = require('./set-class');
+import setClass from './set-class';
 
 var unhighlight = function (klass, color) {
 	if (klass === undefined)
@@ -8,4 +8,4 @@ var unhighlight = function (klass, color) {
 	setClass(this.elemset, "", klass, color);
 };
 
-module.exports = unhighlight;
+export default unhighlight;

--- a/test.js
+++ b/test.js
@@ -1,32 +1,39 @@
-var abcjs = require('./index');
-var version = require('./version');
+import abcjs from './index'
+import version from './version'
 
 abcjs.signature = "abcjs-test v" + version;
 
-abcjs.renderMidi = require('./src/api/abc_tunebook_midi');
+import renderMidi from './src/api/abc_tunebook_midi'
+abcjs.renderMidi = renderMidi
 
-var parser = require('./src/parse/abc_parse');
-abcjs['parse'] = { Parse: parser };
+import parser from './src/parse/abc_parse'
+abcjs.parse = { Parse: parser };
 
-var engraverController = require('./src/write/abc_engraver_controller');
-abcjs['write'] = { EngraverController: engraverController };
+import engraverController from './src/write/abc_engraver_controller'
+abcjs.write = { EngraverController: engraverController };
 
-var midi = require('./src/midi/abc_midi_controls');
-var sequence = require('./src/synth/abc_midi_sequencer');
-var flatten = require('./src/synth/abc_midi_flattener');
-var midiCreate = require('./src/midi/abc_midi_create');
-var midiUiGenerator = require('./src/midi/abc_midi_ui_generator');
-abcjs['midi'] = midi;
-abcjs['midi'].sequence = sequence;
-abcjs['midi'].flatten = flatten;
-abcjs['midi'].create = midiCreate;
-abcjs['midi'].midiUiGenerator = midiUiGenerator;
+import midi from './src/midi/abc_midi_controls'
+import sequence from './src/synth/abc_midi_sequencer'
+import flatten from './src/synth/abc_midi_flattener'
+import midiCreate from './src/midi/abc_midi_create'
+import midiUiGenerator from './src/midi/abc_midi_ui_generator'
+abcjs.midi = midi;
+abcjs.midi.sequence = sequence;
+abcjs.midi.flatten = flatten;
+abcjs.midi.create = midiCreate;
+abcjs.midi.midiUiGenerator = midiUiGenerator;
 
-var parserLint = require('./src/test/abc_parser_lint');
-var verticalLint = require('./src/test/abc_vertical_lint');
-var midiLint = require('./src/test/abc_midi_lint');
-var midiSequencerLint = require('./src/test/abc_midi_sequencer_lint');
-var renderingLint = require('./src/test/rendering-lint');
-abcjs['test'] = { ParserLint: parserLint, verticalLint: verticalLint, midiLint: midiLint, midiSequencerLint: midiSequencerLint, renderingLint: renderingLint };
+import parserLint from './src/test/abc_parser_lint'
+import verticalLint from './src/test/abc_vertical_lint'
+import midiLint from './src/test/abc_midi_lint'
+import midiSequencerLint from './src/test/abc_midi_sequencer_lint'
+import renderingLint from './src/test/rendering-lint'
+abcjs.test = {
+	ParserLint: parserLint,
+	verticalLint: verticalLint,
+	midiLint: midiLint,
+	midiSequencerLint: midiSequencerLint,
+	renderingLint: renderingLint
+};
 
-module.exports = abcjs;
+export default abcjs;

--- a/version.js
+++ b/version.js
@@ -1,3 +1,3 @@
-var version = '6.0.0-beta.15';
+const version = '6.0.0-beta.15';
 
-module.exports = version;
+export default version;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = ({mode, presets, type} = {mode: "production", presets: []}) => 
 					commonjs: 'abcjs'
 				},
 				libraryTarget: 'umd',
+				libraryExport: 'default',
 				globalObject: 'this'
 			},
 			mode,


### PR DESCRIPTION
This changes all `module.exports` to `export default` and all `var xxx = require('xxx')` to `import xxx from 'xxx'`
It also sets up webpack to serve the library correctly with the `libraryExports` option and package.json `module` option so webpack knows where to package the library from .
and finally sets the package.json `main` entry point to point to the generated output file instead.

Es6 files can now be access directly with `import abcjs from 'abcjs/index'`
older cross browser suppot is given with the transpiled files in the `dist` directory. With the package.json `main` entrypoint pointing to the transpiled location a normal `import abcjs from abcjs` will pull in the already transpiled file meaning theres no need for a user to worry about transpiling after an `npm install` unless they use the src files directly and are supporting older browsers.