### PR TITLE
parser refactoring

### DIFF
--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -457,9 +457,9 @@ var Parse = function() {
 		header.reset(tokenizer, warn, multilineVars, tune);
 
 		// Take care of whatever line endings come our way
-		strTune = parseCommon.gsub(strTune, '\r\n', '\n');
-		strTune = parseCommon.gsub(strTune, '\r', '\n');
-		strTune += '\n';	// Tacked on temporarily to make the last line continuation work
+		// Tack on newline temporarily to make the last line continuation work
+		strTune = strTune.replace(/\r\n?/, '\n') + '\n';
+
 		// get rid of latex commands. If a line starts with a backslash, then it is replaced by spaces to keep the character count the same.
 		var arr = strTune.split("\n\\");
 		if (arr.length > 1) {

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -366,6 +366,11 @@ var Parse = function() {
 	};
 
 	var parseLine = function(line) {
+		if (parseCommon.startsWith(line, '%%')) {
+			var err = parseDirective.addDirective(line.substring(2));
+			if (err) warn(err, line, 2);
+			return;
+		}
 		var ret = header.parseHeader(line);
 		if (ret.regular)
 			music.parseMusic(ret.str);

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -380,6 +380,11 @@ var Parse = function() {
 		if (line.length === 0)
 			return;
 
+		if (line.length < 2 || line.charAt(1) !== ':') {
+			music.parseMusic(line);
+			return
+		}
+
 		var ret = header.parseHeader(line);
 		if (ret.regular)
 			music.parseMusic(ret.str);

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -458,7 +458,7 @@ var Parse = function() {
 
 		// Take care of whatever line endings come our way
 		// Tack on newline temporarily to make the last line continuation work
-		strTune = strTune.replace(/\r\n?/, '\n') + '\n';
+		strTune = strTune.replace(/\r\n?/g, '\n') + '\n';
 
 		// get rid of latex commands. If a line starts with a backslash, then it is replaced by spaces to keep the character count the same.
 		var arr = strTune.split("\n\\");

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -387,7 +387,7 @@ var Parse = function() {
 
 		var ret = header.parseHeader(line);
 		if (ret.regular)
-			music.parseMusic(ret.str);
+			music.parseMusic(line);
 		if (ret.newline)
 			music.startNewLine();
 		if (ret.words)

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -472,8 +472,7 @@ var Parse = function() {
 			strTune = arr.join("  "); //. the split removed two characters, so this puts them back
 		}
 		var continuationReplacement = function(all, backslash, comment){
-			var spaces = "                                                                                                                                                                                                     ";
-			var padding = comment ? spaces.substring(0, comment.length) : "";
+			var padding = comment ? Array(comment.length +1).join(' ') : "";
 			return backslash + " \x12" + padding;
 		};
 		strTune = strTune.replace(/\\([ \t]*)(%.*)*\n/g, continuationReplacement);	// take care of line continuations right away, but keep the same number of characters

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -371,6 +371,15 @@ var Parse = function() {
 			if (err) warn(err, line, 2);
 			return;
 		}
+
+		var i = line.indexOf('%');
+		if (i >= 0)
+			line = line.substring(0, i);
+		line = line.replace(/\s+$/, '');
+
+		if (line.length === 0)
+			return;
+
 		var ret = header.parseHeader(line);
 		if (ret.regular)
 			music.parseMusic(ret.str);

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -527,27 +527,28 @@ var Parse = function() {
 
 			multilineVars.openSlurs = tuneBuilder.cleanUp(multilineVars.barsperstaff, multilineVars.staffnonote, multilineVars.openSlurs);
 
-			var ph = 11*72;
-			var pl = 8.5*72;
-			switch (multilineVars.papersize) {
-				//case "letter": ph = 11*72; pl = 8.5*72; break;
-				case "legal": ph = 14*72; pl = 8.5*72; break;
-				case "A4": ph = 11.7*72; pl = 8.3*72; break;
-			}
-			if (multilineVars.landscape) {
-				var x = ph;
-				ph = pl;
-				pl = x;
-			}
-			if (!tune.formatting.pagewidth)
-				tune.formatting.pagewidth = pl;
-			if (!tune.formatting.pageheight)
-				tune.formatting.pageheight = ph;
-
 		} catch (err) {
 			if (err !== "normal_abort")
 				throw err;
 		}
+
+		var ph = 11*72;
+		var pl = 8.5*72;
+		switch (multilineVars.papersize) {
+			//case "letter": ph = 11*72; pl = 8.5*72; break;
+			case "legal": ph = 14*72; pl = 8.5*72; break;
+			case "A4": ph = 11.7*72; pl = 8.3*72; break;
+		}
+		if (multilineVars.landscape) {
+			var x = ph;
+			ph = pl;
+			pl = x;
+		}
+		if (!tune.formatting.pagewidth)
+			tune.formatting.pagewidth = pl;
+		if (!tune.formatting.pageheight)
+			tune.formatting.pageheight = ph;
+
 		if (switches.hint_measures) {
 			addHintMeasures();
 		}

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -524,6 +524,9 @@ var Parse = function() {
 				}
 				multilineVars.iChar += line.length + 1;
 			});
+
+			multilineVars.openSlurs = tuneBuilder.cleanUp(multilineVars.barsperstaff, multilineVars.staffnonote, multilineVars.openSlurs);
+
 			var ph = 11*72;
 			var pl = 8.5*72;
 			switch (multilineVars.papersize) {
@@ -536,7 +539,11 @@ var Parse = function() {
 				ph = pl;
 				pl = x;
 			}
-			multilineVars.openSlurs = tuneBuilder.cleanUp(pl, ph, multilineVars.barsperstaff, multilineVars.staffnonote, multilineVars.openSlurs);
+			if (!tune.formatting.pagewidth)
+				tune.formatting.pagewidth = pl;
+			if (!tune.formatting.pageheight)
+				tune.formatting.pageheight = ph;
+
 		} catch (err) {
 			if (err !== "normal_abort")
 				throw err;

--- a/src/parse/abc_parse_header.js
+++ b/src/parse/abc_parse_header.js
@@ -474,8 +474,11 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 	};
 
 	this.parseHeader = function(line) {
-		if (line.length >= 2) {
-			if (line.charAt(1) === ':') {
+		if (line.length < 2 || line.charAt(1) !== ':') {
+			// If we got this far, we have a regular line of mulsic
+			return {regular: true, str: line};
+		}
+
 				var nextLine = "";
 				if (line.indexOf('\x12') >= 0 && line.charAt(0) !== 'w') {	// w: is the only header field that can have a continuation.
 					nextLine = line.substring(line.indexOf('\x12')+1);
@@ -565,11 +568,6 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 				if (nextLine.length > 0)
 					return {recurse: true, str: nextLine};
 				return {};
-			}
-		}
-
-		// If we got this far, we have a regular line of mulsic
-		return {regular: true, str: line};
 	};
 };
 

--- a/src/parse/abc_parse_header.js
+++ b/src/parse/abc_parse_header.js
@@ -474,14 +474,6 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 	};
 
 	this.parseHeader = function(line) {
-		var i = line.indexOf('%');
-		if (i >= 0)
-			line = line.substring(0, i);
-		line = line.replace(/\s+$/, '');
-
-		if (line.length === 0)
-			return {};
-
 		if (line.length >= 2) {
 			if (line.charAt(1) === ':') {
 				var nextLine = "";

--- a/src/parse/abc_parse_header.js
+++ b/src/parse/abc_parse_header.js
@@ -474,11 +474,6 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 	};
 
 	this.parseHeader = function(line) {
-		if (parseCommon.startsWith(line, '%%')) {
-			var err = parseDirective.addDirective(line.substring(2));
-			if (err) warn(err, line, 2);
-			return {};
-		}
 		var i = line.indexOf('%');
 		if (i >= 0)
 			line = line.substring(0, i);

--- a/src/parse/abc_parse_header.js
+++ b/src/parse/abc_parse_header.js
@@ -552,12 +552,7 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 					warn("Ignored header", line, 0);
 					break;
 				default:
-					// It wasn't a recognized header value, so parse it as music.
-					if (nextLine.length)
-						nextLine = "\x12" + nextLine;
-					//parseRegularMusicLine(line+nextLine);
-					//nextLine = "";
-					return {regular: true, str: line+nextLine};
+					return {regular: true};
 			}
 		}
 		if (nextLine.length > 0)

--- a/src/parse/abc_parse_header.js
+++ b/src/parse/abc_parse_header.js
@@ -474,11 +474,6 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 	};
 
 	this.parseHeader = function(line) {
-		if (line.length < 2 || line.charAt(1) !== ':') {
-			// If we got this far, we have a regular line of mulsic
-			return {regular: true, str: line};
-		}
-
 				var nextLine = "";
 				if (line.indexOf('\x12') >= 0 && line.charAt(0) !== 'w') {	// w: is the only header field that can have a continuation.
 					nextLine = line.substring(line.indexOf('\x12')+1);

--- a/src/parse/abc_parse_header.js
+++ b/src/parse/abc_parse_header.js
@@ -474,95 +474,95 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 	};
 
 	this.parseHeader = function(line) {
-				var nextLine = "";
-				if (line.indexOf('\x12') >= 0 && line.charAt(0) !== 'w') {	// w: is the only header field that can have a continuation.
-					nextLine = line.substring(line.indexOf('\x12')+1);
-					line = line.substring(0, line.indexOf('\x12'));	//This handles a continuation mark on a header field
-				}
-				var field = metaTextHeaders[line.charAt(0)];
-				if (field !== undefined) {
-					if (field === 'unalignedWords')
-						tuneBuilder.addMetaTextArray(field, parseDirective.parseFontChangeLine(tokenizer.translateString(tokenizer.stripComment(line.substring(2)))));
-					else
-						tuneBuilder.addMetaText(field, tokenizer.translateString(tokenizer.stripComment(line.substring(2))));
-					return {};
-				} else {
-					var startChar = multilineVars.iChar;
-					var endChar = startChar + line.length;
-					switch(line.charAt(0))
-					{
-						case  'H':
-							tuneBuilder.addMetaText("history", tokenizer.translateString(tokenizer.stripComment(line.substring(2))));
-							multilineVars.is_in_history = true;
-							break;
-						case  'K':
-							// since the key is the last thing that can happen in the header, we can resolve the tempo now
-							this.resolveTempo();
-							var result = parseKeyVoice.parseKey(line.substring(2));
-							if (!multilineVars.is_in_header && tuneBuilder.hasBeginMusic()) {
-								if (result.foundClef)
-									tuneBuilder.appendStartingElement('clef', startChar, endChar, multilineVars.clef);
-								if (result.foundKey)
-									tuneBuilder.appendStartingElement('key', startChar, endChar, parseKeyVoice.fixKey(multilineVars.clef, multilineVars.key));
-							}
-							multilineVars.is_in_header = false;	// The first key signifies the end of the header.
-							break;
-						case  'L':
-							this.setDefaultLength(line, 2, line.length);
-							break;
-						case  'M':
-							multilineVars.origMeter = multilineVars.meter = this.setMeter(line.substring(2));
-							break;
-						case  'P':
-							// TODO-PER: There is more to do with parts, but the writer doesn't care.
-							if (multilineVars.is_in_header)
-								tuneBuilder.addMetaText("partOrder", tokenizer.translateString(tokenizer.stripComment(line.substring(2))));
-							else
-								multilineVars.partForNextLine = { title: tokenizer.translateString(tokenizer.stripComment(line.substring(2))), startChar: startChar, endChar: endChar};
-							break;
-						case  'Q':
-							var tempo = this.setTempo(line, 2, line.length);
-							if (tempo.type === 'delaySet') multilineVars.tempo = tempo.tempo;
-							else if (tempo.type === 'immediate') {
-								if (!tune.metaText.tempo)
-									tune.metaText.tempo = tempo.tempo;
-								else
-									multilineVars.tempoForNextLine = ['tempo', startChar, endChar, tempo.tempo]
-							}
-							break;
-						case  'T':
-							this.setTitle(line.substring(2));
-							break;
-						case 'U':
-							this.addUserDefinition(line, 2, line.length);
-							break;
-						case  'V':
-							parseKeyVoice.parseVoice(line, 2, line.length);
-							if (!multilineVars.is_in_header)
-								return {newline: true};
-							break;
-						case  's':
-							return {symbols: true};
-						case  'w':
-							return {words: true};
-						case 'X':
-							break;
-						case 'E':
-						case 'm':
-							warn("Ignored header", line, 0);
-							break;
-						default:
-							// It wasn't a recognized header value, so parse it as music.
-							if (nextLine.length)
-								nextLine = "\x12" + nextLine;
-							//parseRegularMusicLine(line+nextLine);
-							//nextLine = "";
-							return {regular: true, str: line+nextLine};
+		var nextLine = "";
+		if (line.indexOf('\x12') >= 0 && line.charAt(0) !== 'w') {	// w: is the only header field that can have a continuation.
+			nextLine = line.substring(line.indexOf('\x12')+1);
+			line = line.substring(0, line.indexOf('\x12'));	//This handles a continuation mark on a header field
+		}
+		var field = metaTextHeaders[line.charAt(0)];
+		if (field !== undefined) {
+			if (field === 'unalignedWords')
+				tuneBuilder.addMetaTextArray(field, parseDirective.parseFontChangeLine(tokenizer.translateString(tokenizer.stripComment(line.substring(2)))));
+			else
+				tuneBuilder.addMetaText(field, tokenizer.translateString(tokenizer.stripComment(line.substring(2))));
+			return {};
+		} else {
+			var startChar = multilineVars.iChar;
+			var endChar = startChar + line.length;
+			switch(line.charAt(0))
+			{
+				case  'H':
+					tuneBuilder.addMetaText("history", tokenizer.translateString(tokenizer.stripComment(line.substring(2))));
+					multilineVars.is_in_history = true;
+					break;
+				case  'K':
+					// since the key is the last thing that can happen in the header, we can resolve the tempo now
+					this.resolveTempo();
+					var result = parseKeyVoice.parseKey(line.substring(2));
+					if (!multilineVars.is_in_header && tuneBuilder.hasBeginMusic()) {
+						if (result.foundClef)
+							tuneBuilder.appendStartingElement('clef', startChar, endChar, multilineVars.clef);
+						if (result.foundKey)
+							tuneBuilder.appendStartingElement('key', startChar, endChar, parseKeyVoice.fixKey(multilineVars.clef, multilineVars.key));
 					}
-				}
-				if (nextLine.length > 0)
-					return {recurse: true, str: nextLine};
-				return {};
+					multilineVars.is_in_header = false;	// The first key signifies the end of the header.
+					break;
+				case  'L':
+					this.setDefaultLength(line, 2, line.length);
+					break;
+				case  'M':
+					multilineVars.origMeter = multilineVars.meter = this.setMeter(line.substring(2));
+					break;
+				case  'P':
+					// TODO-PER: There is more to do with parts, but the writer doesn't care.
+					if (multilineVars.is_in_header)
+						tuneBuilder.addMetaText("partOrder", tokenizer.translateString(tokenizer.stripComment(line.substring(2))));
+					else
+						multilineVars.partForNextLine = { title: tokenizer.translateString(tokenizer.stripComment(line.substring(2))), startChar: startChar, endChar: endChar};
+					break;
+				case  'Q':
+					var tempo = this.setTempo(line, 2, line.length);
+					if (tempo.type === 'delaySet') multilineVars.tempo = tempo.tempo;
+					else if (tempo.type === 'immediate') {
+						if (!tune.metaText.tempo)
+							tune.metaText.tempo = tempo.tempo;
+						else
+							multilineVars.tempoForNextLine = ['tempo', startChar, endChar, tempo.tempo]
+					}
+					break;
+				case  'T':
+					this.setTitle(line.substring(2));
+					break;
+				case 'U':
+					this.addUserDefinition(line, 2, line.length);
+					break;
+				case  'V':
+					parseKeyVoice.parseVoice(line, 2, line.length);
+					if (!multilineVars.is_in_header)
+						return {newline: true};
+					break;
+				case  's':
+					return {symbols: true};
+				case  'w':
+					return {words: true};
+				case 'X':
+					break;
+				case 'E':
+				case 'm':
+					warn("Ignored header", line, 0);
+					break;
+				default:
+					// It wasn't a recognized header value, so parse it as music.
+					if (nextLine.length)
+						nextLine = "\x12" + nextLine;
+					//parseRegularMusicLine(line+nextLine);
+					//nextLine = "";
+					return {regular: true, str: line+nextLine};
+			}
+		}
+		if (nextLine.length > 0)
+			return {recurse: true, str: nextLine};
+		return {};
 	};
 };
 

--- a/src/parse/abc_parse_header.js
+++ b/src/parse/abc_parse_header.js
@@ -475,7 +475,7 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 
 	this.parseHeader = function(line) {
 		var nextLine = "";
-		if (line.indexOf('\x12') >= 0 && line.charAt(0) !== 'w') {	// w: is the only header field that can have a continuation.
+		if (line.indexOf('\x12') >= 0) {
 			nextLine = line.substring(line.indexOf('\x12')+1);
 			line = line.substring(0, line.indexOf('\x12'));	//This handles a continuation mark on a header field
 		}

--- a/src/parse/tune-builder.js
+++ b/src/parse/tune-builder.js
@@ -146,7 +146,7 @@ var TuneBuilder = function(tune) {
 		}
 	}
 
-	this.cleanUp = function(defWidth, defLength, barsperstaff, staffnonote, currSlur) {
+	this.cleanUp = function(barsperstaff, staffnonote, currSlur) {
 		this.closeLine();	// Close the last line.
 		delete tune.runningFonts;
 
@@ -450,11 +450,6 @@ var TuneBuilder = function(tune) {
 				}
 			}
 		}
-
-		if (!tune.formatting.pagewidth)
-			tune.formatting.pagewidth = defWidth;
-		if (!tune.formatting.pageheight)
-			tune.formatting.pageheight = defLength;
 
 		// Remove temporary variables that the outside doesn't need to know about
 		delete tune.staffNum;


### PR DESCRIPTION
main changes...

swap how the line ending is managed by using `string.prototype.replace' with a `/\r\n?/` regex instead of the `parseCommon.gsub' function.

Improve the character replacement for comments after line continuation chars. this allows for unlimited character replacement. this doesnt fix character counts for errors but I'm hoping to get to that eventually.

Initially move all of the page sizing logic to one place. which allows us to remove the `tuneBuilder.cleanUp` arguments.

then move the sizing logic outside of the try catch block this ensures size directives will always be passed to the tune when `header_only` is set, However this now means the tune will always have `formatting.pageWidth` and `formatting.pageHeigth` properties. Although I can't see this as an issue as it just gives the Tune better defaults and I cant see the properties used anywhere in the library.

edit: 
added a few more commits 
moves most of the line type decision tree logic from the `headerParser` to the main parser.