### PR TITLE
Line continuations

### DIFF
--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -472,7 +472,7 @@ var Parse = function() {
 		// take care of line continuations right away, but keep the same number of characters
 		strTune = strTune.replace(/\\([ \t]*)(%.*)*\n/g, function(all, backslash, comment){
 			var padding = comment ? Array(comment.length +1).join(' ') : "";
-			return backslash + " \x12" + padding;
+			return backslash + "\x12" + padding + '\n';
 		});
 		var lines = strTune.split('\n')
 		if (parseCommon.last(lines).length === 0)	// remove the blank line we added above.

--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -14,7 +14,7 @@ var Parse = function() {
 	"use strict";
 	var tune = new Tune();
 	var tuneBuilder = new TuneBuilder(tune);
-	var tokenizer = new Tokenizer();
+	var tokenizer;
 
 	this.getTune = function() {
 		var t = {
@@ -453,6 +453,31 @@ var Parse = function() {
 		if (!switches) switches = {};
 		if (!startPos) startPos = 0;
 		tuneBuilder.reset();
+
+		// Take care of whatever line endings come our way
+		// Tack on newline temporarily to make the last line continuation work
+		strTune = strTune.replace(/\r\n?/g, '\n') + '\n';
+
+		// get rid of latex commands. If a line starts with a backslash, then it is replaced by spaces to keep the character count the same.
+		var arr = strTune.split("\n\\");
+		if (arr.length > 1) {
+			for (var i2 = 1; i2 < arr.length; i2++) {
+				while (arr[i2].length > 0 && arr[i2][0] !== "\n") {
+					arr[i2] = arr[i2].substr(1);
+					arr[i2-1] += ' ';
+				}
+			}
+			strTune = arr.join("  "); //. the split removed two characters, so this puts them back
+		}
+		// take care of line continuations right away, but keep the same number of characters
+		strTune = strTune.replace(/\\([ \t]*)(%.*)*\n/g, function(all, backslash, comment){
+			var padding = comment ? Array(comment.length +1).join(' ') : "";
+			return backslash + " \x12" + padding;
+		});
+		var lines = strTune.split('\n')
+		if (parseCommon.last(lines).length === 0)	// remove the blank line we added above.
+			lines.pop();
+		tokenizer = new Tokenizer(lines);
 		header = new ParseHeader(tokenizer, warn, multilineVars, tune, tuneBuilder);
 		music = new ParseMusic(tokenizer, warn, multilineVars, tune, tuneBuilder, header);
 
@@ -475,34 +500,12 @@ var Parse = function() {
 		}
 		header.reset(tokenizer, warn, multilineVars, tune);
 
-		// Take care of whatever line endings come our way
-		// Tack on newline temporarily to make the last line continuation work
-		strTune = strTune.replace(/\r\n?/g, '\n') + '\n';
-
-		// get rid of latex commands. If a line starts with a backslash, then it is replaced by spaces to keep the character count the same.
-		var arr = strTune.split("\n\\");
-		if (arr.length > 1) {
-			for (var i2 = 1; i2 < arr.length; i2++) {
-				while (arr[i2].length > 0 && arr[i2][0] !== "\n") {
-					arr[i2] = arr[i2].substr(1);
-					arr[i2-1] += ' ';
-				}
-			}
-			strTune = arr.join("  "); //. the split removed two characters, so this puts them back
-		}
-		var continuationReplacement = function(all, backslash, comment){
-			var padding = comment ? Array(comment.length +1).join(' ') : "";
-			return backslash + " \x12" + padding;
-		};
-		strTune = strTune.replace(/\\([ \t]*)(%.*)*\n/g, continuationReplacement);	// take care of line continuations right away, but keep the same number of characters
-		var lines = strTune.split('\n');
-		if (parseCommon.last(lines).length === 0)	// remove the blank line we added above.
-			lines.pop();
 		try {
 			if (switches.format) {
 				parseDirective.globalFormatting(switches.format);
 			}
-			parseCommon.each(lines,  function(line) {
+			var line = tokenizer.nextLine();
+			while (line) {
 				if (switches.header_only && multilineVars.is_in_header === false)
 					throw "normal_abort";
 				if (switches.stop_on_warning && multilineVars.warnings)
@@ -542,7 +545,8 @@ var Parse = function() {
 					}
 				}
 				multilineVars.iChar += line.length + 1;
-			});
+				line = tokenizer.nextLine();
+			}
 
 			multilineVars.openSlurs = tuneBuilder.cleanUp(multilineVars.barsperstaff, multilineVars.staffnonote, multilineVars.openSlurs);
 

--- a/src/parse/abc_parse_music.js
+++ b/src/parse/abc_parse_music.js
@@ -8,6 +8,7 @@ var multilineVars;
 var tune;
 var tuneBuilder;
 var header;
+var lineContinuation = false;;
 
 var MusicParser = function(_tokenizer, _warn, _multilineVars, _tune, _tuneBuilder, _header) {
 	tokenizer = _tokenizer;
@@ -135,7 +136,7 @@ MusicParser.prototype.parseMusic = function(line) {
 			//multilineVars.start_new_line = false;
 		} else {
 			// Wait until here to actually start the line because we know we're past the inline statements.
-			if (delayStartNewLine) {
+			if (!tuneBuilder.hasBeginMusic() || (delayStartNewLine && !lineContinuation)) {
 				this.startNewLine();
 				delayStartNewLine = false;
 			}
@@ -562,6 +563,7 @@ MusicParser.prototype.parseMusic = function(line) {
 			}
 		}
 	}
+	lineContinuation = line.indexOf('\x12') >= 0;
 };
 
 var setIsInTie =function(multilineVars, overlayLevel, value) {

--- a/src/parse/abc_tokenizer.js
+++ b/src/parse/abc_tokenizer.js
@@ -6,7 +6,10 @@ var parseCommon = require('./abc_common');
 // the return is the number of characters consumed, so 0 means that the element wasn't found.
 // also returned is the element found. This may be a different length because spaces may be consumed that aren't part of the string.
 // The return structure for most calls is { len: num_chars_consumed, token: str }
-var Tokenizer = function() {
+var Tokenizer = function(lines) {
+	this.lineIndex = 0
+	this.lines = lines
+
 	this.skipWhiteSpace = function(str) {
 		for (var i = 0; i < str.length; i++) {
 		  if (!this.isWhiteSpace(str.charAt(i)))
@@ -737,5 +740,14 @@ var Tokenizer = function() {
 		}
 	};
 };
+
+Tokenizer.prototype.nextLine = function() {
+	if (this.lineIndex < this.lines.length) {
+		var result = this.lines[this.lineIndex]
+		this.lineIndex++
+		return result
+	}
+	return null
+}
 
 module.exports = Tokenizer;


### PR DESCRIPTION
This improves on how line continuations are parsed.

Currently any line continuation followed by a directive line or (i believe) any heaeder line will not parse the following line correctly.

As the line continuation function in the `Parse.parse` method joins lines ending with a `\` with the next line before any parsing can be done. This causes the individual line parsers to read two lines such as this
`
abc \
%%directive
`
as 
`
abc \%%directive
`
as soon as this line is parsed the directive is parsed as a end of line comment instead.
This can easily be tested with the above example as removing the line continuation will then correctly give an error for the `%%directive`