### PR TITLE
Fix tablature default tuning and documentation

### DIFF
--- a/docs/visual/tablature.md
+++ b/docs/visual/tablature.md
@@ -10,7 +10,7 @@ Here is a simple example using the options `{tablature: [{instrument: 'violin'}]
 <show-and-render-abc :abc="`X:1\nT: Cooley's\nM: 4/4\nL: 1/8\nR: reel\nK: G\n|:D2|EB{c}BA B2 EB|~B2 AB dBAG|FDAD BDAD|FDAD dAFD|\n`" :options="{tablature: [ {instrument: 'violin'}]}">
 </show-and-render-abc>
 
-To get tablature to appear, add the option `abcjs.renderAbc("paper", abc, { tablatures: [...] }` as described below.
+To get tablature to appear, add the option `abcjs.renderAbc("paper", abc, { tablature: [...] }` as described below.
 
 ::: tip Credits
 Thanks to Jean-Yves Mengant ([@jymen](https://github.com/jymen)) for leading the effort to include tablature and for writing the code. Check out his site [ABCMusicStudio](https://www.jymengant.org/).
@@ -20,27 +20,32 @@ Thanks to Jean-Yves Mengant ([@jymen](https://github.com/jymen)) for leading the
 
 The tablature option is an array where each item in the array represents a voice in the music. That is,
 if you want to represent tablature for a string quartet, you would structure it like this:
+
 ```javascript
 abcjs.renderAbc("paper", abc, {
-	tablatures: [
-		{
-			// first violin options
-		}, {
-			// second violin options
-		}, {
-			// viola options
-		}, {
-			// cello options
-		}
-	]
-})
+  tablature: [
+    {
+      // first violin options
+    },
+    {
+      // second violin options
+    },
+    {
+      // viola options
+    },
+    {
+      // cello options
+    },
+  ],
+});
 ```
-If there are more voices in the music than are in the above array, the extra voices will not have tablature. If there
-are more voices in the above array then in the music, then the extra voices will be ignored.
+
+If there are more voices in the music than are in the above array, the extra voices will not have tablature. If there are more voices in the above array than in the music, the extra voices will be ignored.
 
 ## Tablature options
 
 ### instrument
+
 default: undefined
 
 Options: "violin" | "guitar" | ""
@@ -49,25 +54,28 @@ This is one of the predefined tablature types. If it is an empty string then tha
 If it is an unrecognized instrument type, then the voice is skipped and a warning is added.
 
 ### label
+
 default: undefined
 
 This is the text that is printed underneath the tablature as explanation. Whatever is passed in is printed.
 
 There is a special sequence to add the tuning. If `%T` is present, then the tuning of the strings is inserted, starting
 from the lowest pitch. For example:
+
 ```javascript
-tablatures: [
-	{
-		instrument: 'guitar',
-		label: "Guitar (%T)",
-		tuning: ['D,', 'A,', 'D', 'G', 'A', 'd']
-	}
-]
+tablature: [
+  {
+    instrument: "guitar",
+    label: "Guitar (%T)",
+    tuning: ["D,", "A,", "D", "G", "A", "d"],
+  },
+];
 ```
+
 will print the string `Guitar (DADGAD)` under each tablature line.
 
-
 ### tuning
+
 default: The standard tuning for that instrument
 
 This is an array of notes that represent the open strings, starting from the lowest pitch
@@ -75,25 +83,27 @@ of the instrument. This is useful for musical styles that use alternate tunings.
 defaults:
 
 ```javascript
-tablatures: [
-	{
-		instrument: 'violin',
-		tuning: ['G,', 'D,', 'A', 'e']
-	},
-	{
-		instrument: 'guitar',
-		tuning: ['E,', 'A,', 'D', 'G', 'B', 'e']
-	}
-]
+tablature: [
+  {
+    instrument: "violin",
+    tuning: ["G,", "D", "A", "e"],
+  },
+  {
+    instrument: "guitar",
+    tuning: ["E,", "A,", "D", "G", "B", "e"],
+  },
+];
 ```
 
 ### capo
+
 default: 0
 
 The number of frets that a capo is placed. This will transpose the numbers so that the open
 string is on the fret of the capo.
 
 ### highestNote
+
 default: `a'`.
 
 This defines the highest note that can be played on that instrument. If a note is out of range a question mark will be printed instead.
@@ -109,7 +119,7 @@ For example,
 
 ```
 abcjs.renderAbc("paper", abc, {
-	tablatures: [
+	tablature: [
 		{
 			instrument: "violin"
 		}
@@ -119,7 +129,6 @@ abcjs.renderAbc("paper", abc, {
         tabnumberfont: "Times 12"
     }
 ```
-
 
 You can also use a preprocessing directive inside the abc string:
 

--- a/src/tablatures/instruments/guitar/guitar-patterns.js
+++ b/src/tablatures/instruments/guitar/guitar-patterns.js
@@ -3,7 +3,7 @@ var StringPatterns = require('../string-patterns');
 function GuitarPatterns(plugin) {
   this.tuning = plugin._super.params.tuning;
   if (!this.tuning) {
-    this.tuning = ['E,', 'A', 'D', 'G' , 'B' , 'e'];
+    this.tuning = ['E,', 'A,', 'D', 'G' , 'B' , 'e'];
   }
   plugin.tuning = this.tuning;
   this.strings = new StringPatterns(plugin);


### PR DESCRIPTION
The correct option for renderAbc seems to be `tablature` rather than `tablatures`. This has been updated for the documentation along with a few other issues. For example, the _documented_ default tuning for violin was invalid due to an extra comma.

In addition, the _actual_ default tuning for guitar was invalid due to a missing comma. This has been corrected so that guitar tablature should work under the default settings.