### PR TITLE
ensure CreateSynth().prime() resolves by using timeouts to avoid gett…

### DIFF
--- a/src/synth/create-synth.js
+++ b/src/synth/create-synth.js
@@ -325,12 +325,24 @@ function CreateSynth() {
 			Promise.all(allPromises).then(function() {
 				// Safari iOS can mess with the audioContext state, so resume if needed.
 				if (activeAudioContext().state === "suspended") {
+					var resumeTimeout = null
+					var resumeTimeout = setTimeout(function() {
+						resolve(resolveData(self))
+					},500)
 					activeAudioContext().resume().then(function () {
+						clearTimeout(resumeTimeout)
 						resolve(resolveData(self));
 					})
+				
 				} else if (activeAudioContext().state === "interrupted") {
+					var resumeTimeout = null
+					var resumeTimeout = setTimeout(function() {
+						resolve(resolveData(self))
+					},500)
+					
 					activeAudioContext().suspend().then(function () {
 						activeAudioContext().resume().then(function () {
+							clearTimeout(resumeTimeout)
 							resolve(resolveData(self));
 						})
 					})


### PR DESCRIPTION
I'm working on a tunebook using React and abcjs => https://github.com/syntithenai/abc2book

To minimise users waiting, I am priming the audio when the abc  prop to the react component changes without respect to mouse click. 

The AudioContext is fine to be initialised and loaded without clicking, it's just resuming that quietly fails.

When resuming without having clicked on the page, resume hangs and the promise returned by the prime method never resolves.

I have added setTimeouts of 500ms to resolve in case resuming fails.


