### PR TITLE
Implement 'octave' modifier for K: and V: fields

### DIFF
--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -78,6 +78,7 @@ var Parse = function() {
 			this.hasMainTitle = false;
 			this.default_length = 0.125;
 			this.clef = { type: 'treble', verticalPos: 0 };
+			this.octave = 0;
 			this.next_note_duration = 0;
 			this.start_new_line = true;
 			this.is_in_header = true;

--- a/src/parse/abc_parse_key_voice.js
+++ b/src/parse/abc_parse_key_voice.js
@@ -408,6 +408,16 @@ var parseKeyVoice = {};
 					multilineVars.clef.staffscale = tokens[0].floatt;
 					tokens.shift();
 					break;
+				case "octave":
+					tokens.shift();
+					if (tokens.length === 0) { warn("Expected = after octave", str, 0); return ret; }
+					token = tokens.shift();
+					if (token.token !== "=") { warn("Expected = after octave", str, token.start); break; }
+					if (tokens.length === 0) { warn("Expected parameter after octave=", str, 0); return ret; }
+					if (tokens[0].type !== 'number') { warn("Expected number after octave", str, tokens[0].start); break; }
+					multilineVars.octave = tokens[0].intt;
+					tokens.shift();
+					break;
 				case "style":
 					tokens.shift();
 					if (tokens.length === 0) { warn("Expected = after style", str, 0); return ret; }
@@ -716,7 +726,6 @@ var parseKeyVoice = {};
 						addNextTokenToVoiceInfo(id, 'staffscale', 'number');
 						break;
 					case 'octave':
-						// TODO-PER: This is accepted, but not implemented, yet.
 						addNextTokenToVoiceInfo(id, 'octave', 'number');
 						break;
 					case 'volume':

--- a/src/parse/abc_parse_music.js
+++ b/src/parse/abc_parse_music.js
@@ -1128,6 +1128,7 @@ var getCoreNote = function(line, index, el, canHaveBrokenRhythm) {
 			case 'g':
 				if (state === 'startSlur' || state === 'sharp2' || state === 'flat2' || state === 'pitch') {
 					el.pitch = pitches[line.charAt(index)];
+					el.pitch += 7 * (multilineVars.currentVoice && multilineVars.currentVoice.octave !== undefined ? multilineVars.currentVoice.octave : multilineVars.octave);
 					el.name = line.charAt(index);
 					if (el.accidental)
 						el.name = accMap[el.accidental] + el.name;


### PR DESCRIPTION
Based on [this section](https://abcnotation.com/wiki/abc:standard:v2.1#clefs_and_transposition) from the ABC music standard (with [clarifications](https://abcnotation.com/wiki/abc:standard:v2.2#the_octave_modifier) from the working draft). This should resolve issue #101.

The `octave` modifier can be set on key and voice fields to directly change the pitch values of ABC code, raising or lowering all pitches by one or more octaves. This applies before any visual or audio transposition and should be equivalent to adding/removing `'` or `,` to note names.

In the example below, all four voices should be equivalent.

```
K: bass
[V:v1]            C,D,E,F,     G,A,B,C     |  % default is octave=0
[V:v2 octave=-1]  CDEF         GABc        |  % read ABC code in Voice 2 down one octave (read c as C)
[V:v3 octave=-2]  cdef         gabc'       |  % read ABC code in Voice 3 down two octaves (read c as C,)
[V:v4 octave=1]   C,,D,,E,,F,, G,,A,,B,,C, |  % read ABC code in Voice 4 up one octave (read c as c')
%
K: octave=1
[V:v1]            C,,D,,E,,F,, G,,A,,B,,C, | % use value of octave specified in K: (useful for tunes with a single voice)
[V:v2]            CDEF         GABc        | % value given in V: (octave=-1) still overrides value in K:
[V:v3]            cdef         gabc'       | % value given in V: (octave=-2) still overrides value in K:
[V:v4 octave=0]   C,D,E,F,     G,A,B,C     | % new value overrides old value given in V: for Voice 4
```

In my implementation, I put the pitch shift directly in the music parser, to parallel how `'` and `,` are handled. Is there any reason this should be moved to the code for `transpose` or anywhere else?