### PR TITLE
a minimal server for serving tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:basic": "npm run webpack -- --mode development --config-name basic",
     "build:basic-min": "npm run webpack -- --mode production --config-name basic",
     "build:plugin": "npm run webpack -- --mode production --config-name plugin",
+    "test-server": "node test-server.js",
     "test": "echo 'To run tests, open the file tests/all.html in a browser.'",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",

--- a/test-server.js
+++ b/test-server.js
@@ -1,0 +1,44 @@
+/**
+ * A minimal web server, serving the /tests directory so that the test
+ * pages can be accessed without CORS.
+ */
+
+const http = require('http');
+const url = require('url');
+const fs = require('fs');
+const path = require('path');
+
+const host = 'localhost';
+const port = 8000;
+
+// Base Directory - Assuming minimal-http-server
+// will be accessed  from its own folder.
+const baseDir = path.join(__dirname, './');
+
+const requestListener = function (request, response) {
+  response.setHeader('Content-Type', 'text/html');
+
+  const parsedUrl = url.parse(request.url, true);
+  let pathName = parsedUrl.pathname;
+
+  // load content
+  fs.readFile(`${baseDir}${pathName}`, (error, data) => {
+    if (!error) {
+      response.writeHead(200);
+      response.end(data);
+    } else {
+      console.log(error);
+      response.writeHead(404);
+      response.end('404 - File Not Found');
+    }
+  });
+
+  //response.writeHead(200);
+  //response.end('My first server!');
+};
+
+const server = http.createServer(requestListener);
+
+server.listen(port, host, () => {
+  console.log(`Server is running on http://${host}:${port}`);
+});

--- a/test-server.js
+++ b/test-server.js
@@ -32,9 +32,6 @@ const requestListener = function (request, response) {
       response.end('404 - File Not Found');
     }
   });
-
-  //response.writeHead(200);
-  //response.end('My first server!');
 };
 
 const server = http.createServer(requestListener);


### PR DESCRIPTION
Loading an html for tests (like all.html) file throws CORS exceptions:

![image](https://user-images.githubusercontent.com/462445/198343408-33e4d159-01bb-416f-8fd3-cf594bb3c93d.png)

Here is a minimal web server that allows opening `http://localhost:8000/tests/all.html`.

Let me know if this is a good approach and the direction you'd like this to go in. My idea would be to have a test-server running and a separate test runner (in addition to the html pages) like Playwright.