### PR TITLE
Metronome support

### DIFF
--- a/src/synth/abc_midi_flattener.js
+++ b/src/synth/abc_midi_flattener.js
@@ -145,6 +145,7 @@ var pitchesToPerc = require('./pitches-to-perc');
 							startingMeter = element;
 						meter = element;
 						beatFraction = getBeatFraction(meter);
+						drumDefinition = metronomeDrumDefinition(70);
 						break;
 					case "tempo":
 						if (!startingTempo)
@@ -1129,6 +1130,17 @@ var pitchesToPerc = require('./pitches-to-perc');
 		}
 	}
 
+	function metronomeDrumDefinition(metronomeVolume) {
+		let beats = meter.num;
+		let pattern = "d".repeat(beats);
+		let instruments = [76].concat(Array(beats-1).fill(77));
+		let volumes = Array(+beats).fill(metronomeVolume);
+		return normalizeDrumDefinition({
+			on: true,
+			bars: 1,
+			pattern: [pattern, ...instruments, ...volumes]
+		});
+	}
 	function normalizeDrumDefinition(params) {
 		// Be very strict with the drum definition. If anything is not perfect,
 		// just turn the drums off.


### PR DESCRIPTION
ABC notation does not have metronome support. There is a workaround of using drum pattern, which can be quite complicated if the meter changes frequently. Also there is a bug in abcjs if the meter changes. (#849)

We can add a "metronomeVolume" parameter and abcjs can automatically calculates drum strings every time when meter changes. 