### PR TITLE
Fix type: AbcVisualParams format object

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -259,7 +259,7 @@ declare module 'abcjs' {
 		dragColor?: string;
 		dragging?: boolean;
 		foregroundColor?: string;
-		format?: { [attr in FormatAttributes]: any };
+		format?: { [attr in FormatAttributes]?: any };
 		header_only?: boolean;
 		initialClef?: boolean;
 		jazzchords?: boolean;


### PR DESCRIPTION
This is a small fix for the type of the 'format' object in ABCVisualParams.

Currently, TypeScript says that every property of the format object is required. This change makes all the properties of the format object optional, so that it doesn't require every format/font to be given.