### PR TITLE
Add a `getIsRunning()` function to enable play/pause. resolves #915

### DIFF
--- a/src/synth/create-synth.js
+++ b/src/synth/create-synth.js
@@ -511,6 +511,10 @@ function CreateSynth() {
 		return self.audioBuffers[0];
 	};
 
+	self.getIsRunning = function() {
+		return self.isRunning;
+	}
+
 	/////////////// Private functions //////////////
 
 	self._deviceCapable = function() {

--- a/tests/synth.html
+++ b/tests/synth.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>Audio Tests</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+	<link rel="stylesheet" href="../abcjs-audio.css" />
+</head>
+<body>
+<div id="mocha"></div>
+<div id="paper"></div>
+<div id="midi"></div>
+<script src="../node_modules/chai/chai.js"></script>
+<script src="../node_modules/mocha/mocha.js"></script>
+<script class="mocha-init">
+	mocha.setup({ui: 'bdd', globals: ['__VUE_DEVTOOLS_TOAST__']});
+	mocha.checkLeaks();
+</script>
+
+<script src="synth/synth-api.test.js"></script>
+
+<script src="../node_modules/@tarp/require/require.min.js"></script>
+<script>
+	Tarp.require({main: "../index.js"}).then(function (response) {
+		window.abcjs = response;
+		mocha.run();
+	});
+</script>
+
+</body>
+</html>

--- a/tests/synth/synth-api.test.js
+++ b/tests/synth/synth-api.test.js
@@ -1,0 +1,17 @@
+
+describe("CreateSynth() / midiBuffer Consumer API", () => {
+  it("has expected functions", () => {
+    const midiBuffer = new abcjs.synth.CreateSynth();
+
+    // only declaring types from index.d.ts::MidiBuffer
+    chai.assert.isFunction(midiBuffer.init, "init()");
+    chai.assert.isFunction(midiBuffer.prime, "prime()");
+    chai.assert.isFunction(midiBuffer.start, "start()");
+    chai.assert.isFunction(midiBuffer.pause, "pause()");
+    chai.assert.isFunction(midiBuffer.resume, "resume()");
+    chai.assert.isFunction(midiBuffer.seek, "seek()");
+    chai.assert.isFunction(midiBuffer.stop, "stop()");
+    chai.assert.isFunction(midiBuffer.download, "download()");
+    chai.assert.isFunction(midiBuffer.getIsRunning, "getIsRunning()");
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1150,6 +1150,7 @@ declare module 'abcjs' {
 		seek(position: number, units?: ProgressUnit): void
 		stop(): number
 		download(): string // returns audio buffer in wav format as a reference to a blob
+		getIsRunning(): boolean
 	}
 
 	export interface SynthInitResponse {


### PR DESCRIPTION
Changes:
* add function to synth
* add declaration of function in type/interface
* add a test file that tests existence of function

The existing synth test was called web_audio.html and was a special case because it requires user interaction to start music. testing API felt like it should be plain and simple, so added a new test route to synth.