### PR TITLE
Clear isLoaded flag in setTune

### DIFF
--- a/src/synth/synth-controller.js
+++ b/src/synth/synth-controller.js
@@ -51,6 +51,7 @@ function SynthController() {
 			self.isStarted = false;
 		}
 		self.isLooping = false;
+		self.isLoaded = false;
 
 		if (userAction)
 			return self.go();


### PR DESCRIPTION
I was attempting to update a synth controller in the background by running something like
```
synthControl.setTune(visualObj, false);
```
However, after I played the tune once any further calls to `setTune` would have no effect on the synth controller. This is because the `isLoaded` flag is not cleared by `setTune`, and when `userAction` is `false` the `isLoaded` flag causes the deferred call to `go` (in `runWhenReady`) to be skipped.

Solution: clear the `isLoaded` flag in `setTune`.