### PR TITLE
Breath

### DIFF
--- a/src/write/creation/decoration.js
+++ b/src/write/creation/decoration.js
@@ -166,6 +166,7 @@ var stackedDecoration = function (decoration, width, abselem, yPos, positioning,
 	}
 
     // MAE START OF CHANGE 24 Nov 2023
+	// Draws breath mark symbol slightly to the right of the target note
 	function symbolDecorationBreath(symbol, placement) {
 		var deltaX = width*1.5;
 		var height = glyphs.symbolHeightInPitches(symbol) + 1; // adding a little padding so nothing touches.

--- a/src/write/creation/decoration.js
+++ b/src/write/creation/decoration.js
@@ -165,6 +165,20 @@ var stackedDecoration = function (decoration, width, abselem, yPos, positioning,
 		incrementPlacement(placement, height);
 	}
 
+  // MAE START OF CHANGE 24 Nov 2023
+	function symbolDecorationBreath(symbol, placement) {
+		var deltaX = width*1.5;
+		var height = glyphs.symbolHeightInPitches(symbol) + 1; // adding a little padding so nothing touches.
+		var y = getPlacement(placement);
+		y = placement === 'above' ? y + height / 2 : y - height / 2; // Center the element vertically.
+		abselem.addFixedX(new RelativeElement(symbol, deltaX, glyphs.getSymbolWidth(symbol), y, {
+		klass: 'ornament',
+		thickness: glyphs.symbolHeightInPitches(symbol)
+		}));
+		incrementPlacement(placement, height);
+	}
+  // MAE END OF CHANGE
+
 	var symbolList = {
 		"+": "scripts.stopped",
 		"open": "scripts.open",
@@ -249,20 +263,28 @@ var stackedDecoration = function (decoration, width, abselem, yPos, positioning,
 			case "downbow":
 			case "upbow":
 			case "fermata":
-			case "breath":
+			// MAE START OF CHANGE
+			//case "breath":
+			// MAE END OF CHANGE
 			case "umarcato":
 			case "coda":
 			case "segno":
 				symbolDecoration(symbolList[decoration[i]], positioning);
 				hasOne = true;
 				break;
+			// MAE START OF CHANGE
+			case "breath":
+				symbolDecorationBreath(symbolList[decoration[i]], positioning);
+				hasOne = true;
+				break;
+			// MAE END OF CHANGE
 			case "invertedfermata":
 				symbolDecoration(symbolList[decoration[i]], 'below');
 				hasOne = true;
 				break;
 			case "mark":
 				abselem.klass = "mark";
-				break;
+				break;		
 		}
 	}
 	return hasOne;

--- a/src/write/creation/decoration.js
+++ b/src/write/creation/decoration.js
@@ -165,7 +165,7 @@ var stackedDecoration = function (decoration, width, abselem, yPos, positioning,
 		incrementPlacement(placement, height);
 	}
 
-  // MAE START OF CHANGE 24 Nov 2023
+    // MAE START OF CHANGE 24 Nov 2023
 	function symbolDecorationBreath(symbol, placement) {
 		var deltaX = width*1.5;
 		var height = glyphs.symbolHeightInPitches(symbol) + 1; // adding a little padding so nothing touches.
@@ -177,7 +177,7 @@ var stackedDecoration = function (decoration, width, abselem, yPos, positioning,
 		}));
 		incrementPlacement(placement, height);
 	}
-  // MAE END OF CHANGE
+    // MAE END OF CHANGE
 
 	var symbolList = {
 		"+": "scripts.stopped",


### PR DESCRIPTION
Offsetting the breath mark rendering slightly to the right. Previously was rendered immediately above the note.

 I had one of my users requested this, agrees with what I'd expect as a flute player.
 
 Results in this:
 
 
![image](https://github.com/paulrosen/abcjs/assets/7969711/4bf58fbc-7fdf-48d4-84b3-07d98a06a481)
