### PR TITLE
Make tablabelfont and tabnumber font changable in the ABC

### DIFF
--- a/src/parse/abc_parse_directive.js
+++ b/src/parse/abc_parse_directive.js
@@ -979,6 +979,10 @@ var parseDirective = {};
 			case "voicefont":
 			case "footerfont":
 			case "headerfont":
+			// MAE START OF CHANGE - Make the tab name and number fonts available for change by users in the ABC
+			case "tablabelfont": 
+			case "tabnumberfont": 
+			// MAE END OF CHANGE
 				return getGlobalFont(cmd, tokens, str);
 			case "barlabelfont":
 			case "barnumberfont":

--- a/src/write/creation/decoration.js
+++ b/src/write/creation/decoration.js
@@ -165,6 +165,20 @@ var stackedDecoration = function (decoration, width, abselem, yPos, positioning,
 		incrementPlacement(placement, height);
 	}
 
+  // MAE START OF CHANGE 24 Nov 2023
+	function symbolDecorationBreath(symbol, placement) {
+		var deltaX = width*1.5;
+		var height = glyphs.symbolHeightInPitches(symbol) + 1; // adding a little padding so nothing touches.
+		var y = getPlacement(placement);
+		y = placement === 'above' ? y + height / 2 : y - height / 2; // Center the element vertically.
+		abselem.addFixedX(new RelativeElement(symbol, deltaX, glyphs.getSymbolWidth(symbol), y, {
+		klass: 'ornament',
+		thickness: glyphs.symbolHeightInPitches(symbol)
+		}));
+		incrementPlacement(placement, height);
+	}
+  // MAE END OF CHANGE
+
 	var symbolList = {
 		"+": "scripts.stopped",
 		"open": "scripts.open",
@@ -249,20 +263,28 @@ var stackedDecoration = function (decoration, width, abselem, yPos, positioning,
 			case "downbow":
 			case "upbow":
 			case "fermata":
-			case "breath":
+			// MAE START OF CHANGE
+			//case "breath":
+			// MAE END OF CHANGE
 			case "umarcato":
 			case "coda":
 			case "segno":
 				symbolDecoration(symbolList[decoration[i]], positioning);
 				hasOne = true;
 				break;
+			// MAE START OF CHANGE
+			case "breath":
+				symbolDecorationBreath(symbolList[decoration[i]], positioning);
+				hasOne = true;
+				break;
+			// MAE END OF CHANGE
 			case "invertedfermata":
 				symbolDecoration(symbolList[decoration[i]], 'below');
 				hasOne = true;
 				break;
 			case "mark":
 				abselem.klass = "mark";
-				break;
+				break;		
 		}
 	}
 	return hasOne;

--- a/src/write/creation/decoration.js
+++ b/src/write/creation/decoration.js
@@ -165,7 +165,7 @@ var stackedDecoration = function (decoration, width, abselem, yPos, positioning,
 		incrementPlacement(placement, height);
 	}
 
-  // MAE START OF CHANGE 24 Nov 2023
+    // MAE START OF CHANGE 24 Nov 2023
 	function symbolDecorationBreath(symbol, placement) {
 		var deltaX = width*1.5;
 		var height = glyphs.symbolHeightInPitches(symbol) + 1; // adding a little padding so nothing touches.
@@ -177,7 +177,7 @@ var stackedDecoration = function (decoration, width, abselem, yPos, positioning,
 		}));
 		incrementPlacement(placement, height);
 	}
-  // MAE END OF CHANGE
+    // MAE END OF CHANGE
 
 	var symbolList = {
 		"+": "scripts.stopped",


### PR DESCRIPTION
While previously these could be set in code in the setup for the abcjs tune rendering, I found that I could not set them using %%tablabelfont or %%tabnumberfont in the ABC itself. 

This change adds them to the global list of fonts that can be changed by ABC. With this change in place I was able to change both of the fonts in my ABC test cases.



