### PR TITLE
Change for #965 - "Centered text offset when using expandtowidest set…

### DIFF
--- a/src/write/engraver-controller.js
+++ b/src/write/engraver-controller.js
@@ -237,37 +237,89 @@ EngraverController.prototype.constructTuneElements = function (abcTune) {
 };
 
 EngraverController.prototype.engraveTune = function (abcTune, tuneNumber, lineOffset) {
-	var scale = this.setupTune(abcTune, tuneNumber);
 
+	var scale = this.setupTune(abcTune, tuneNumber);
+  
 	// Create all of the element objects that will appear on the page.
 	this.constructTuneElements(abcTune);
-
+  
+	//Set the top text now that we know the width
+  
 	// Do all the positioning, both horizontally and vertically
 	var maxWidth = layout(this.renderer, abcTune, this.width, this.space, this.expandToWidest);
-
+  
 	//Set the top text now that we know the width
-	if (this.expandToWidest && maxWidth > this.width+1) {
-		abcTune.topText = new TopText(abcTune.metaText, abcTune.metaTextInfo, abcTune.formatting, abcTune.lines, maxWidth, this.renderer.isPrint, this.renderer.padding.left, this.renderer.spacing, this.getTextSize);
+	if (this.expandToWidest && maxWidth > this.width + 1) {
+  
+	  abcTune.topText = new TopText(abcTune.metaText, abcTune.metaTextInfo, abcTune.formatting, abcTune.lines, maxWidth, this.renderer.isPrint, this.renderer.padding.left, this.renderer.spacing, this.getTextSize);
+  
+	  if ((abcTune.lines)&&(abcTune.lines.length > 0)){
+  
+		var nlines = abcTune.lines.length;
+  
+		for (var i=0;i<nlines;++i){
+  
+		  var entry = abcTune.lines[i];
+  
+		  if (entry.nonMusic){
+  
+			if ((entry.nonMusic.rows) && (entry.nonMusic.rows.length > 0)){
+  
+			  var nRows = entry.nonMusic.rows.length;
+  
+			  for (var j=0;j<nRows;++j){
+  
+				var thisRow = entry.nonMusic.rows[j];
+  
+				// Recenter the element if it's a subtitle or centered text 
+				if (thisRow.left){
+  
+				  if (entry.subtitle){
+  
+					//console.log("Got centered subtitle: "+entry.subtitle.text);
+  
+					thisRow.left = (maxWidth/2) + this.renderer.padding.left;
+  
+				  }
+				  else
+				  if ((entry.text)&&(entry.text.length>0)){
+  
+					if (entry.text[0].center){
+  
+					  //debugger;
+  
+					  //console.log("Got centered text element: "+entry.text[0].text);
+  
+					  thisRow.left = (maxWidth/2) + this.renderer.padding.left;
+  
+					}
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  }
 	}
 
 	// Deal with tablature for staff
 	if (abcTune.tablatures) {
-		tablatures.layoutTablatures(this.renderer, abcTune);
+	  tablatures.layoutTablatures(this.renderer, abcTune);
 	}
-
+  
 	// Do all the writing to the SVG
 	var ret = draw(this.renderer, this.classes, abcTune, this.width, maxWidth, this.responsive, scale, this.selectTypes, tuneNumber, lineOffset);
 	this.staffgroups = ret.staffgroups;
 	this.selectables = ret.selectables;
-
 	if (this.oneSvgPerLine) {
-		var div = this.renderer.paper.svg.parentNode
-		this.svgs = splitSvgIntoLines(this.renderer, div, abcTune.metaText.title, this.responsive)
+	  var div = this.renderer.paper.svg.parentNode;
+	  this.svgs = splitSvgIntoLines(this.renderer, div, abcTune.metaText.title, this.responsive);
 	} else {
-		this.svgs = [this.renderer.paper.svg];
+	  this.svgs = [this.renderer.paper.svg];
 	}
 	setupSelection(this, this.svgs);
-};
+	
+  };
 
 function splitSvgIntoLines(renderer, output, title, responsive) {
 	// Each line is a top level <g> in the svg. To split it into separate


### PR DESCRIPTION
This fixes both the offset of centered text and additional centered T: subtitles embedded in the ABC (not in header) in tunes who have their width adjusted using expandtowidest set to true.

Before:

![image](https://github.com/paulrosen/abcjs/assets/7969711/63304033-28ec-41ea-8b92-c391863751b9)

After:

![image](https://github.com/paulrosen/abcjs/assets/7969711/7f406a99-527b-4fda-b427-bcebfb7d06d0)

Test case for rendering with expandtowidest set to true:

X:1
T:The Kail Pot
M:4/4
R:strathspey
Q:140
L:1/8
K:Dmin
|:"Dm"d>^cd>e f>ed>e|"F"f>ef>a "C"ge|"Dm"d>^cd>e f>ed>e|"F"f>ef>a "C"ge|"F"f>ef>a "Gm"g>f"C"e>g|1"A"(3fed (3^cde "Dm"d<D D2:|2"A"(3fed (3^cde "Dm"d<D D|]
% User likes to do this to create tune sets...
T:Airlie Bobbies
T:(by Jim Ritchie, in 1938 age 11)
R:reel
[Q:180]
M:4/4
L:1/8
K:Amaj
%%center Here is some centered text
E|"A"A/A/A AB "E"AECE|"A"AEAc "E"e2 dc|"G"B/B/B Bc BFDF|BABc "D"defd|
