### PR TITLE
Improvements in tab label handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/.vuepress/.temp/*
 docs/.vuepress/.dist/*
 dist/report.html
 .eslintrc.json
+src/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ docs/.vuepress/.temp/*
 docs/.vuepress/.dist/*
 dist/report.html
 .eslintrc.json
-src/.DS_Store

--- a/src/parse/abc_parse_directive.js
+++ b/src/parse/abc_parse_directive.js
@@ -979,6 +979,9 @@ var parseDirective = {};
 			case "voicefont":
 			case "footerfont":
 			case "headerfont":
+			case "tablabelfont": 
+			case "tabnumberfont": 
+			case "tabgracefont":		  
 				return getGlobalFont(cmd, tokens, str);
 			case "barlabelfont":
 			case "barnumberfont":

--- a/src/tablatures/instruments/guitar/tab-guitar.js
+++ b/src/tablatures/instruments/guitar/tab-guitar.js
@@ -26,6 +26,8 @@ Plugin.prototype.init = function (abcTune, tuneNumber, params) {
 
   var semantics = new GuitarPatterns(this);
   this.semantics = semantics;
+  this.isFirstStaff = true;
+  this.firstTabNameHeight = 1;
 };
 
 Plugin.prototype.render = function (renderer, line, staffIndex) {

--- a/src/tablatures/instruments/violin/tab-violin.js
+++ b/src/tablatures/instruments/violin/tab-violin.js
@@ -24,6 +24,8 @@ Plugin.prototype.init = function (abcTune, tuneNumber, params) {
     this.linePitch);
   var semantics = new ViolinPatterns(this);
   this.semantics = semantics;
+  this.isFirstStaff = true;
+  this.firstTabNameHeight = 1;
 };
 
 Plugin.prototype.render = function (renderer, line, staffIndex) {

--- a/src/tablatures/tab-renderer.js
+++ b/src/tablatures/tab-renderer.js
@@ -214,11 +214,16 @@ TabRenderer.prototype.doLayout = function () {
   // staffGroup.staffs.push(staffGroupInfos);
   staffGroup.height += this.tabSize + padd;
   var parentStaff = getLastStaff(staffGroup.staffs, nextTabPos);
+
   var nbVoices = 1;
-  if (isMultiVoiceSingleStaff(staffGroup.staffs, parentStaff)) {
+  var isMultiVoice = isMultiVoiceSingleStaff(staffGroup.staffs, parentStaff);
+  if (isMultiVoice) {
     nbVoices = parentStaff.voices.length;
   }
   
+  // Don't allow tab labels on multi-voice tunes
+  var allowTabLabels = (staffGroup.voices.length == 1);
+
   // build from staff
   this.tabStaff.voices = [];
 
@@ -230,10 +235,19 @@ TabRenderer.prototype.doLayout = function () {
 
     var nameHeight;
 
+    // MAE START OF CHANGE
+
     // First staff with a tab name gets special treatment
     if (this.plugin.isFirstStaff){
     
-      var nameHeight = buildTabName(this, tabVoice) / spacing.STEP;
+      var nameHeight = 0;
+
+      // Don't allow tab labels on multi-voice
+      if (allowTabLabels){
+
+        nameHeight = buildTabName(this, tabVoice) / spacing.STEP;
+
+      }
 
       nameHeight = Math.max(nameHeight, 1); // If there is no label for the tab line, then there needs to be a little padding
       
@@ -250,9 +264,12 @@ TabRenderer.prototype.doLayout = function () {
 
       }
 
-      this.plugin.firstTabNameHeight = nameHeight;
+      if (allowTabLabels){
 
-      this.plugin.isFirstStaff = false;
+        this.plugin.firstTabNameHeight = nameHeight;
+        
+        this.plugin.isFirstStaff = false;
+      }
 
     }
     else{
@@ -262,9 +279,9 @@ TabRenderer.prototype.doLayout = function () {
 
       staffGroup.staffs[this.staffIndex].top += this.plugin.firstTabNameHeight;
 
-
     }
-  
+    // MAE END OF CHANGE
+
     tabVoice.staff = staffGroupInfos;
     
     var tabVoiceIndex = voices.length;
@@ -282,6 +299,7 @@ TabRenderer.prototype.doLayout = function () {
   linkStaffAndTabs(staffGroup.staffs); // crossreference tabs and staff
 
 };
+
 
 
 module.exports = TabRenderer;

--- a/src/tablatures/tab-renderer.js
+++ b/src/tablatures/tab-renderer.js
@@ -180,17 +180,13 @@ TabRenderer.prototype.doLayout = function () {
       if (firstStaff.clef) {
         if (firstStaff.clef.stafflines == 0) {
           this.plugin._super.setError("No tablatures when stafflines=0");
-          return; 
+          return;
         }
       }
     }
-    staffs.splice(
-      staffs.length, 0,
-      this.tabStaff
-    );
+    staffs.splice(staffs.length, 0, this.tabStaff);
   }
   var staffGroup = this.line.staffGroup;
-
   var voices = staffGroup.voices;
   var firstVoice = voices[0];
   // take lyrics into account if any
@@ -209,37 +205,82 @@ TabRenderer.prototype.doLayout = function () {
     lines: this.plugin.nbLines,
     linePitch: this.plugin.linePitch,
     dy: 0.15,
-    top: tabTop,
+    top: tabTop
   };
-  var nextTabPos = getNextTabPos(this,staffGroup.staffs);
-  if (nextTabPos === -1)
-    return;
+  var nextTabPos = getNextTabPos(this, staffGroup.staffs);
+  if (nextTabPos === -1) return;
   staffGroupInfos.parentIndex = nextTabPos - 1;
   staffGroup.staffs.splice(nextTabPos, 0, staffGroupInfos);
   // staffGroup.staffs.push(staffGroupInfos);
   staffGroup.height += this.tabSize + padd;
-  var parentStaff = getLastStaff(staffGroup.staffs, nextTabPos); 
+  var parentStaff = getLastStaff(staffGroup.staffs, nextTabPos);
   var nbVoices = 1;
-  if (isMultiVoiceSingleStaff(staffGroup.staffs,parentStaff)) {
+  if (isMultiVoiceSingleStaff(staffGroup.staffs, parentStaff)) {
     nbVoices = parentStaff.voices.length;
-  }  
+  }
+  
   // build from staff
   this.tabStaff.voices = [];
+
   for (var ii = 0; ii < nbVoices; ii++) {
+
     var tabVoice = new VoiceElement(0, 0);
+    
     if (ii > 0) tabVoice.duplicate = true;
-    var nameHeight = buildTabName(this, tabVoice) / spacing.STEP;
-    nameHeight = Math.max(nameHeight, 1) // If there is no label for the tab line, then there needs to be a little padding
-    staffGroup.staffs[this.staffIndex].top += nameHeight;
-    staffGroup.height += nameHeight * spacing.STEP;
+
+    var nameHeight;
+
+    // First staff with a tab name gets special treatment
+    if (this.plugin.isFirstStaff){
+    
+      var nameHeight = buildTabName(this, tabVoice) / spacing.STEP;
+
+      nameHeight = Math.max(nameHeight, 1); // If there is no label for the tab line, then there needs to be a little padding
+      
+      staffGroup.staffs[this.staffIndex].top += 1;
+   
+      if (nameHeight == 1){
+
+        staffGroup.height += spacing.STEP;
+
+      }
+      else{
+
+        staffGroup.height += nameHeight;
+
+      }
+
+      this.plugin.firstTabNameHeight = nameHeight;
+
+      this.plugin.isFirstStaff = false;
+
+    }
+    else{
+
+      // Padding
+      staffGroup.height += spacing.STEP;
+
+      staffGroup.staffs[this.staffIndex].top += this.plugin.firstTabNameHeight;
+
+
+    }
+  
     tabVoice.staff = staffGroupInfos;
-    var tabVoiceIndex = voices.length
+    
+    var tabVoiceIndex = voices.length;
+    
     voices.splice(voices.length, 0, tabVoice);
+    
     var keySig = checkVoiceKeySig(voices, ii + this.staffIndex);
+    
     this.tabStaff.voices[ii] = [];
-    this.absolutes.build(this.plugin, voices, this.tabStaff.voices[ii], ii , this.staffIndex ,keySig, tabVoiceIndex);
+    
+    this.absolutes.build(this.plugin, voices, this.tabStaff.voices[ii], ii, this.staffIndex, keySig, tabVoiceIndex);
+  
   }
+
   linkStaffAndTabs(staffGroup.staffs); // crossreference tabs and staff
+
 };
 
 


### PR DESCRIPTION
This fixes the excessive spacing inject with tab labels displayed as well as restricts the tab label to just the first staff.

Unfortunately, the solution doesn't work for multiple-voice tunes, it will need to both adjust the staff top for the grouped tab staves within the voice as well as the following grouped staves, which will all have to move down the total of the height added by the previous staff labels. 

To avoid all of this, I'm making the tradeoff of just not allowing tab labels on multi-voice tunes.   

I totally understand if this is not something you'd want to ship as a general solution for the library, but we can use it as a starting point for a proper solution in the future.