### PR TITLE
Switched from XMLHttpRequest to fetch()

### DIFF
--- a/src/synth/load-note.js
+++ b/src/synth/load-note.js
@@ -5,40 +5,41 @@
 var soundsCache = require("./sounds-cache");
 
 var getNote = function (url, instrument, name, audioContext) {
-	if (!soundsCache[instrument]) soundsCache[instrument] = {};
-	var instrumentCache = soundsCache[instrument];
+  if (!soundsCache[instrument]) soundsCache[instrument] = {};
+  var instrumentCache = soundsCache[instrument];
 
-	if (!instrumentCache[name])
-		instrumentCache[name] = new Promise(function (resolve, reject) {
-			var xhr = new XMLHttpRequest();
-			let noteUrl = url + instrument + "-mp3/" + name + ".mp3";
-			xhr.open("GET", noteUrl, true);
-			xhr.responseType = "arraybuffer";
-			xhr.onload = function () {
-				if (xhr.status !== 200) {
-					reject(Error("Can't load sound at " + noteUrl + ' status=' + xhr.status));
-					return
-				}
-				var noteDecoded = function(audioBuffer) {
-					resolve({instrument: instrument, name: name, status: "loaded", audioBuffer: audioBuffer})
-				}
-				var maybePromise = audioContext.decodeAudioData(xhr.response, noteDecoded, function () {
-					reject(Error("Can't decode sound at " + noteUrl));
-				});
-				// In older browsers `BaseAudioContext.decodeAudio()` did not return a promise
-				if (maybePromise && typeof maybePromise.catch === "function") maybePromise.catch(reject);
-			};
-			xhr.onerror = function () {
-				reject(Error("Can't load sound at " + noteUrl));
-			};
-			xhr.send();
-		})
-			.catch(err => {
-				console.error("Didn't load note", instrument, name, ":", err.message);
-				throw err;
-			});
+  if (!instrumentCache[name])
+    instrumentCache[name] = new Promise(function (resolve, reject) {
+      let noteUrl = url + instrument + "-mp3/" + name + ".mp3";
 
-	return instrumentCache[name];
+      // Use the fetch API instead of XMLHttpRequest
+      fetch(noteUrl)
+      .then(response => {
+          if (!response.ok){
+            throw new Error(`HTTP error, status = ${response.status}`);
+          }
+          response.arrayBuffer().then(theBuffer => {
+            var noteDecoded = function noteDecoded(audioBuffer) {
+              resolve({
+                instrument: instrument,
+                name: name,
+                status: "loaded",
+                audioBuffer: audioBuffer
+              });
+            };
+            var maybePromise = audioContext.decodeAudioData(theBuffer, noteDecoded, function () {
+               reject(Error("Can't decode sound at " + noteUrl));
+            });
+          });
+      })
+      .catch(error => {
+          reject(Error("Can't load sound at " + noteUrl + ' status=' + error));
+          throw error;
+      });
+
+    });
+
+    return instrumentCache[name];
 };
 
 module.exports = getNote;


### PR DESCRIPTION
In my testing with large number of sample reads, using fetch() instead of XMLHttpRequest appears to be faster overall.  

Not sure if it's related to better use of multithreading or perhaps the sample decoding happening async, but with combinations of both the standard and my custom soundfonts, this seems faster to load all the samples.

Tested on my Mac with Safari, Chrome, Firefox, as well as in mobile Safari on my iPad Pro and iPhone 14 Pro Max.