### PR TITLE
Fix types for `strTranspose`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1275,7 +1275,7 @@ declare module 'abcjs' {
 	export function numberOfTunes(abc: string) : number;
 	export function extractMeasures(abc: string) : Array<MeasureList>;
 	
-	export function strTranspose(originalAbc: string, visualObj: TuneObject, steps: number): string;
+	export function strTranspose(originalAbc: string, visualObj: TuneObjectArray, steps: number): string;
 
 	//
 	// Glyph


### PR DESCRIPTION
`strTranspose` expects as its second argument a `TuneObjectArray` as returned by `renderAbc`. However, the typedef incorrectly specified a `TuneObject`. This PR fixes this so that Typescript users won't get thrown off track when trying to pass in the output of `renderAbc`.

(I store the output of `renderAbc` in a variable called `score`. In trying to fix the type errors, I started to pass into `strTranspose` `score[0]` instead of `score`, and spent some non-trivial amount of time trying to figure out why transposition was broken.)