### PR TITLE
Fix linespacing

### DIFF
--- a/src/write/engraver-controller.js
+++ b/src/write/engraver-controller.js
@@ -303,7 +303,7 @@ EngraverController.prototype.engraveTune = function (abcTune, tuneNumber, lineOf
 	this.selectables = ret.selectables;
 	if (this.oneSvgPerLine) {
 	  var div = this.renderer.paper.svg.parentNode;
-	  this.svgs = splitSvgIntoLines(this.renderer, div, abcTune.metaText.title, this.responsive);
+	  this.svgs = splitSvgIntoLines(this.renderer, div, abcTune.metaText.title, this.responsive, scale);
 	} else {
 	  this.svgs = [this.renderer.paper.svg];
 	}
@@ -312,7 +312,7 @@ EngraverController.prototype.engraveTune = function (abcTune, tuneNumber, lineOf
 	this.jazzchords = origJazzChords
 };
 
-function splitSvgIntoLines(renderer, output, title, responsive) {
+function splitSvgIntoLines(renderer, output, title, responsive, scale) {
 	// Each line is a top level <g> in the svg. To split it into separate
 	// svgs iterate through each of those and put them in a new svg. Since
 	// they are placed absolutely, the viewBox needs to be manipulated to
@@ -337,7 +337,7 @@ function splitSvgIntoLines(renderer, output, title, responsive) {
 		var wrapper = document.createElement("div");
 		var divStyles = "overflow: hidden;"
 		if (responsive !== 'resize')
-			divStyles += "height:" + height + "px;"
+			divStyles += "height:" + (height * scale) + "px;"
 		wrapper.setAttribute("style", divStyles)
 		var svg = duplicateSvg(source)
 		var fullTitle = "Sheet Music for \"" + title + "\" section " + (i + 1)


### PR DESCRIPTION
When using the `scale` and `oneSvgPerLine` parameters of the `renderAbc` function, the distance between the lines is not scaled accordantly.

e.g.: A scale factor of 0.3 results in following rendering:
![image](https://github.com/paulrosen/abcjs/assets/389101/483d156c-819d-4d3a-8ef7-3ac4dc114639)

I would expect that the distance is also scaled down like this:
<img width="218" alt="image" src="https://github.com/paulrosen/abcjs/assets/389101/b989949e-f6bd-472b-9417-8ca742906449">

Using a scalefactor greater then 1 will at some point cut the svg, omitting part of the score

I think the height of the div should be scaled down. The height of the SVG will be changed by the transform but the height of the sourounding div is like it wasn't scaled.

Not sure if I found the right position but it worked for my textcase…