### PR TITLE
Bring bass note in range if transposed out-of-range

### DIFF
--- a/src/synth/chord-track.js
+++ b/src/synth/chord-track.js
@@ -198,6 +198,15 @@ ChordTrack.prototype.interpretChord = function (name) {
 	while (chordTranspose > 8)
 		chordTranspose -= 12;
 	bass += chordTranspose;
+	
+    	// MAE 31 Aug 2024 - For visual transpose backup range issue
+    	// If transposed below A or above G, bring it back in the normal backup range
+    	if (bass < 33){
+      		bass += 12;
+    	}
+    	else if (bass > 44){
+	     	 bass -= 12;
+    	}
 
 	// MAE 17 Jun 2024 - Supporting octave shifted bass and chords
 	var unshiftedBass = bass;


### PR DESCRIPTION
Doing a transpose, either a %%MIDI transpose or setting a visual transpose at renderABC time sometimes causes octave changes in the backup.

For example, if you take this tune and do a visual transpose of +2, the G chords that get played are still a G, but down an octave.  This change checks the range of the bass after application of the transpose and brings it into the basses[] array range.

X: 1
T: The Kesh
C: Traditional
R: Jig
M: 6/8
L: 1/8
Q: 3/8=120
K: Gmaj
%
% Use an Acoustic Grand Piano sound for the melody:
%%MIDI program 0
%
% Use an Acoustic Grand Piano for the chords:
%%MIDI chordprog 0
%
% Use an Synth Bass sound for the bass:
%%MIDI bassprog 38
%
|:"G"GAG GAB|"D"ABA ABd|"G"edd gdd|"C"edB "D"dBA|
"G"GAG GAB|"D"ABA ABd|"G"edd gdB|"D"AGF "G"G3:|
|:"G"BAB dBd|"C"ege "D"dBA|"G"BAB dBG|"D"ABA AGA|
"G"BAB dBd|"C"ege "G"dBd|"C"gfg "D"aga|"G"bgf g3:|