### PR TITLE
Fix for crash on malformed @ positioned annotations

### DIFF
--- a/src/parse/abc_parse_music.js
+++ b/src/parse/abc_parse_music.js
@@ -615,23 +615,38 @@ var letter_to_chord = function(line, i) {
 			chord[1] = chord[1].substring(1);
 			chord[2] = 'right';
 		} else if (chord[0] > 0 && chord[1].length > 0 && chord[1][0] === '@') {
-			// @-15,5.7
-			chord[1] = chord[1].substring(1);
-			var x = tokenizer.getFloat(chord[1]);
-			if (x.digits === 0)
-				warn("Missing first position in absolutely positioned annotation.", line , i);
-			chord[1] = chord[1].substring(x.digits);
-			if (chord[1][0] !== ',')
-				warn("Missing comma absolutely positioned annotation.", line , i);
-			chord[1] = chord[1].substring(1);
-			var y = tokenizer.getFloat(chord[1]);
-			if (y.digits === 0)
-				warn("Missing second position in absolutely positioned annotation.", line , i);
-			chord[1] = chord[1].substring(y.digits);
-			var ws = tokenizer.skipWhiteSpace(chord[1]);
-			chord[1] = chord[1].substring(ws);
-			chord[2] = null;
-			chord[3] = { x: x.value, y: y.value };
+		      // @-15,5.7		
+		      chord[1] = chord[1].substring(1);
+		      var x = tokenizer.getFloat(chord[1]);
+		      if (x.digits === 0){
+			warn("Missing first position in absolutely positioned annotation.", line, i);
+			chord[1] = chord[1].replace("@","");
+			chord[2] = 'above';
+			return chord;
+		      }
+		      chord[1] = chord[1].substring(x.digits);
+		      if (chord[1][0] !== ','){
+			warn("Missing comma absolutely positioned annotation.", line, i);
+			chord[1] = chord[1].replace("@","");
+			chord[2] = 'above';
+			return chord;
+		      }
+		      chord[1] = chord[1].substring(1);
+		      var y = tokenizer.getFloat(chord[1]);
+		      if (y.digits === 0){
+			warn("Missing second position in absolutely positioned annotation.", line, i);
+			chord[1] = chord[1].replace("@","");
+			chord[2] = 'above';
+			return chord;
+		      }
+		      chord[1] = chord[1].substring(y.digits);
+		      var ws = tokenizer.skipWhiteSpace(chord[1]);
+		      chord[1] = chord[1].substring(ws);
+		      chord[2] = null;
+		      chord[3] = {
+			x: x.value,
+			y: y.value
+		      };	
 		} else {
 			if (multilineVars.freegchord !== true) {
 				chord[1] = chord[1].replace(/([ABCDEFG0-9])b/g, "$1♭");


### PR DESCRIPTION
If a malformed "@"-style absolute positioned annotation was encountered, the renderer would throw an exception.

This change returns a reasonable chord value that that won't crash the rendering while a malformed absolute positioned annotation is being edited, which is a very common occurrence.

For example lets say user intends to add an annotation:

"@-30,20Hello"

While they are typing this, "@-30Hello" won't crash as it would before with this change in place.  

Once the user finally finished typing the full annotation: 

"@-30,20Hello"

then it will be rendered at the absolute position requested.