### PR TITLE
fix: MidiBuffer should work without options.

### DIFF
--- a/src/synth/create-synth.js
+++ b/src/synth/create-synth.js
@@ -315,7 +315,7 @@ function CreateSynth() {
 
 			var noteMapTracks = createNoteMap(self.flattened);
 
-			if (self.options.swing)
+			if (self.options?.swing)
 				addSwing(noteMapTracks, self.options.swing, self.meterFraction, self.pickupLength)
 
 			if (self.sequenceCallback)


### PR DESCRIPTION
## Acknowledgment
First of all, I would like to express my gratitude to the maintainers and contributors of abcjs for creating and maintaining such a powerful and versatile library. Your work has made it easier for developers like me to integrate musical notation and playback into web applications.

While exploring the synthesized sound functionality, I encountered a minor issue with the handling of the options parameter in MidiBuffer.init(). This PR is a small attempt to contribute back and improve the library further. Thank you for your continued efforts in maintaining this project and for considering this contribution.

## Problem
In the current implementation of `MidiBuffer.init()`, the `options.options` parameter is set to `undefined` by default([reference](https://paulrosen.github.io/abcjs/audio/synthesized-sound.html#init-synthoptions)).  However, the code does not properly initialize this parameter, resulting in an error when `MidiBuffer.prime()` attempts to access `self.options.swing`. Specifically, at this [line](https://github.com/paulrosen/abcjs/blob/main/src/synth/create-synth.js#L318), the code tries to reference `self.options.swing` without handling the case where `self.options` is `undefined`.

This leads to the following error during playback:
```
TypeError: Cannot read properties of undefined (reading 'swing')
```

## Proposed Solution
Modify the condition at [create-synth.js#L318](https://github.com/paulrosen/abcjs/blob/main/src/synth/create-synth.js#L318) to safely access `self.options.swing` by using optional chaining (`self.options?.swing`). This ensures that `prime()` does not throw an error if `self.options` is undefined.

This fix aligns with the existing behavior of `MidiBuffer.init()` and ensures that the function works seamlessly without requiring `options` to be explicitly defined.

## Additional Context
If the current behavior is intentional and `options` is expected to be initialized as an empty object when not provided, an alternative approach would be to ensure `options` is always initialized within `MidiBuffer.init()`.

### Alternative Fix
```javascript
self.options = options || {};
```

This would ensure that `self.options` is always defined, avoiding the need for optional chaining in subsequent references.

