### PR TITLE
note volume per note within chord

### DIFF
--- a/src/synth/abc_midi_sequencer.js
+++ b/src/synth/abc_midi_sequencer.js
@@ -442,7 +442,7 @@ var parseCommon = require("../parse/abc_common");
 				}
 
 				function setDynamics(elem) {
-					var volumes = {
+					var volumes = {//stressBeat1, stressBeatDown, stressBeatUp
 						'pppp': [15, 10, 5, 1],
 						'ppp': [30, 20, 10, 1],
 						'pp': [45, 35, 20, 1],
@@ -480,7 +480,14 @@ var parseCommon = require("../parse/abc_common");
 
 						if (dynamicType) {
 							currentVolume = volumes[dynamicType].slice(0);
-							voices[voiceNumber].push({ el_type: 'beat', beats: currentVolume.slice(0) });
+							let volumesPerNotePitch = [currentVolume];
+							if(Array.isArray(elem.decoration)){
+								volumesPerNotePitch = [];
+								elem.decoration.forEach(d=>{
+									volumesPerNotePitch.push(volumes[d].slice(0));
+								});
+							}
+							voices[voiceNumber].push({ el_type: 'beat', beats: currentVolume.slice(0), volumesPerNotePitch: volumesPerNotePitch, });
 							inCrescendo[k] = false;
 							inDiminuendo[k] = false;
 						}


### PR DESCRIPTION
Allows specification of different volumes per note within a chord.

You can already specify the dynamics within the chord for each note and the parser already picks that up correctly. With this changes, that information is no longer ignored, but calculates and stores the note-based volume information next to the chord's stressBeat information, so I can use it where the notemap for midi is created per note. It follows the existing. With this change you can write this: [!pppp!c!ffff!^g] to have a chord played back with a soft c and loud g.

Perhaps good to know:
- It is supposed to be backwards compatible
- The change can be done in a nicer way with some refactoring. This is purposely not done here.
- The dynamics visualization is unmodified and will likely overlap. This can be hidden with css:
[data-name="dynamics"]{
    display: none;
    /* color: red; */
}
- It seems to me there is currently no clean way yet to show additional information per note in a chord. "<x", will write the x at the height of the chord and is not allowed within a chord, so that can only be used to some extend to compensate.