### PR TITLE
Updated algorithm to determine direction of single beams

### DIFF
--- a/src/write/layout/beam.js
+++ b/src/write/layout/beam.js
@@ -189,7 +189,22 @@ function createAdditionalBeams(elems, asc, beam, isGrace, dy) {
 
 
 				if (auxBeams[j].single) {
-					auxBeamEndX = (i === 0) ? x + 5 : x - 5;
+					if(i === 0) {
+						// This is the first note in the group, always draw the beam to the right
+						auxBeamEndX = x + 5;
+					} else if (i === elems.length - 1) {
+						// This is the last note in the group, always draw the beam to the left
+						auxBeamEndX = x - 5;
+					} else {
+						// This is a middle note, check the note durations of the notes to the left and right
+						if(elems[i-1].duration === elems[i+1].duration) {
+						// The notes on either side are the same duration, alternate which side the beam goes to
+						auxBeamEndX = i%2 === 0 ? x + 5 : x - 5;
+						} else {
+						// The notes on either side are different durations, draw the beam to the shorter note
+						auxBeamEndX = elems[i-1].duration > elems[i+1].duration ? x + 5 : x - 5;
+						}
+					}
 					auxBeamEndY = getBarYAt(beam.startX, beam.startY, beam.endX, beam.endY, auxBeamEndX) + sy * (j + 1);
 				}
 				var b = { startX: auxBeams[j].x, endX: auxBeamEndX, startY: auxBeams[j].y, endY: auxBeamEndY, dy: dy }


### PR DESCRIPTION
This addresses issue #1114 by attempting to add some "intelligence" to the algorithm that determines the direction of "single" (ie. not connected to another note) beams, rather than always drawing them to the left.

An example is `{GdGe}B{g}c1/4d3/4` which currently looks like:

<img width="414" height="219" alt="image" src="https://github.com/user-attachments/assets/3dcdeac7-dbac-40ae-a973-8b1ba249fb23" />

and looks like this after the fix:

<img width="417" height="187" alt="image" src="https://github.com/user-attachments/assets/a9d3e50e-09a9-4745-9f8f-9f661fc8a76a" />

The decision to draw beams towards the shorter note is consistent with the approach used by abcm2ps, however the full algorithm in abcm2ps is more sophisticated and would require a major refactor of abcjs to work identically.

In the event of a "tie" where both notes are the same duration, I have opted to alternate direction based on even/odd note index in the group, which is somewhat arbitrary but achieves acceptable results in some working examples.

Overall, this is not a perfect fix but I would argue it's a nice "80/20" that achieves better results than the current approach with no refactoring required.