### PR TITLE
Fix an issue with wrong TimingCallbacks startTime

### DIFF
--- a/src/api/abc_timing_callbacks.js
+++ b/src/api/abc_timing_callbacks.js
@@ -49,11 +49,11 @@ var TimingCallbacks = function(target, params) {
 		if (self.lastTimestamp === timestamp)
 			return; // If there are multiple seeks or other calls, then we can easily get multiple callbacks for the same instant.
 		self.lastTimestamp = timestamp;
-		if (!self.startTime) {
-			self.startTime = timestamp;
-		}
 
 		if (!self.isPaused && self.isRunning) {
+			if (!self.startTime) {
+				self.startTime = timestamp;
+			}
 			self.currentTime = timestamp - self.startTime;
 			self.currentTime += 16; // Add a little slop because this function isn't called exactly.
 			while (self.noteTimings.length > self.currentEvent && self.noteTimings[self.currentEvent].milliseconds < self.currentTime) {


### PR DESCRIPTION
After a song has finished playing sometimes the `doTiming` handler inside `TimingCallbacks` would still get called. This caused the `startTime` to be updated and thus if you resumed playback afterwards the `TimingCallbacks` would already have a `startTime` and start somewhere halfway through the notes.

I noticed this issue when calling `timingCallbacks.stop()` from inside the `eventCallback` handler upon receiving a `null` event. The subsequent `start` call I made would have the `timingCallbacks` start halfway through the piece.