### PR TITLE
Fix beaming when there's a rest

### DIFF
--- a/src/write/layout/beam.js
+++ b/src/write/layout/beam.js
@@ -212,13 +212,12 @@ function createAdditionalBeams(elems, asc, beam, isGrace, dy) {
 				var auxBeamEndX = x;
 				var auxBeamEndY = bary + sy * (j + 1);
 
-
 				if (auxBeams[j].single) {
 					var prevNonRestIndex = findPrevNonRest(elems, i);
 					var isFirstNote = (prevNonRestIndex === -1);
 					var isLastNote = (nextNonRestIndex === -1);
 					
-					if(isFirstNote) {
+					if (isFirstNote) {
 						// This is the first note in the group, always draw the beam to the right
 						auxBeamEndX = x + 5;
 					} else if (isLastNote) {
@@ -228,7 +227,7 @@ function createAdditionalBeams(elems, asc, beam, isGrace, dy) {
 						// This is a middle note, check the note durations of the notes to the left and right (skipping rests)
 						var prevDuration = elems[prevNonRestIndex].abcelem.duration;
 						var nextDuration = elems[nextNonRestIndex].abcelem.duration;
-						if(prevDuration === nextDuration) {
+						if (prevDuration === nextDuration) {
 							// The notes on either side are the same duration, alternate which side the beam goes to
 							auxBeamEndX = i%2 === 0 ? x + 5 : x - 5;
 						} else {


### PR DESCRIPTION
issue https://github.com/paulrosen/abcjs/issues/1140

## Problem

the `createAdditionalBeams()` function calculated auxiliary beam positions by:
 - checking `elems[i+1]` to decide if a beam should end
 - comparing `elems[i-1]` and `elems[i+1]` durations to determine beam direction for middle notes

These checks didn't skip rest elements, so rests were treated as notes, leading to incorrect beam calculations.

## Fix

Check if an element is a rest

## Testing

I added tests for the z appearing anywhere and loaded like 
`http://localhost:8080/tests/all.html?grep=Miscellaneous%20beamed%5Cx2drest`

<img width="532" height="394" alt="Screenshot 2026-02-07 at 8 21 51 AM" src="https://github.com/user-attachments/assets/f5feb900-777c-4ab1-86b0-901151039ce9" />

And the exact issue as reported looks like

<img width="246" height="292" alt="Screenshot 2026-02-07 at 8 21 36 AM" src="https://github.com/user-attachments/assets/af497468-6a54-4054-a95b-7b4bcf9c4784" />
