### PR TITLE
extend melisma line through notes marked with standalone _ in lyrics

### DIFF
--- a/src/parse/abc_parse.js
+++ b/src/parse/abc_parse.js
@@ -288,16 +288,18 @@ var Parse = function() {
 		line.forEach(function(el) {
 			if (word_list.length !== 0) {
 				if (word_list[0].skip) {
-					switch (word_list[0].to) {
+					var skipTo = word_list[0].to;
+					switch (skipTo) {
 						case 'next': if (el.el_type === 'note' && el.pitches !== null && !inSlur) word_list.shift(); break;
 						case 'slur': if (el.el_type === 'note' && el.pitches !== null) word_list.shift(); break;
 						case 'bar': if (el.el_type === 'bar') word_list.shift(); break;
 					}
 					if (el.el_type !== 'bar') {
+						var skipDivider = skipTo === 'slur' ? '_' : ' ';
 						if (el.lyric === undefined)
-							el.lyric = [{syllable: "", divider: " "}];
+							el.lyric = [{syllable: "", divider: skipDivider}];
 						else
-							el.lyric.push({syllable: "", divider: " "});
+							el.lyric.push({syllable: "", divider: skipDivider});
 					}
 				} else {
 					if (el.el_type === 'note' && el.rest === undefined && !inSlur) {

--- a/src/write/creation/abstract-engraver.js
+++ b/src/write/creation/abstract-engraver.js
@@ -769,7 +769,9 @@ AbstractEngraver.prototype.addNoteToAbcElement = function (abselem, elem, dot, s
 AbstractEngraver.prototype.addLyric = function (abselem, elem) {
 	var lyricStr = "";
 	elem.lyric.forEach(function (ly) {
-		var div = ly.divider === ' ' ? "" : ly.divider;
+		// A "_" divider marks a melisma: it isn't drawn as a glyph, but as a
+		// continuous extender line spanning the covered notes (see lyric-extension.js).
+		var div = (ly.divider === ' ' || ly.divider === '_') ? "" : ly.divider;
 		lyricStr += ly.syllable + div + "\n";
 	});
 	var lyricDim = this.getTextSize.calc(lyricStr, 'vocalfont', "lyric");

--- a/src/write/draw/lyric-extension.js
+++ b/src/write/draw/lyric-extension.js
@@ -35,7 +35,7 @@ function lyricChild(abselem) {
 }
 
 function drawVerseExtensions(renderer, children, verse, selectables) {
-	var run = null; // { startX, endX, y }
+	var run = null; // { startX, endX, y, startChar, endChar }
 	for (var i = 0; i < children.length; i++) {
 		var child = children[i];
 		if (child.type === 'bar')
@@ -63,11 +63,21 @@ function drawVerseExtensions(renderer, children, verse, selectables) {
 		if (ly.syllable && ly.syllable.length > 0) {
 			// This note carries the syllable that begins the melisma.
 			run = flush(renderer, run, selectables);
-			run = { startX: relElem.x + relElem.w / 2 + 2, endX: relElem.x, y: y };
+			run = {
+				startX: relElem.x + relElem.w / 2 + 2,
+				endX: relElem.x,
+				y: y,
+				// The span of ABC source covered by this melisma, tracked so the
+				// line can be matched back to its notes (see the data attributes below).
+				startChar: child.abcelem.startChar,
+				endChar: child.abcelem.endChar
+			};
 		} else if (run) {
 			// A bare "_": extend the current line to cover this note.
 			run.endX = relElem.x;
 			run.y = y;
+			if (child.abcelem.endChar !== undefined)
+				run.endChar = child.abcelem.endChar;
 		}
 	}
 	flush(renderer, run, selectables);
@@ -80,8 +90,20 @@ function flush(renderer, run, selectables) {
 		var endX = Math.max(run.endX, run.startX + 6);
 		var klass = renderer.controller.classes.generate('lyric-extension');
 		var el = printLine(renderer, run.startX, endX, run.y, klass, 'lyric-extension', 0.6);
-		if (el)
-			selectables.wrapSvgEl({ el_type: "extension", startChar: -1, endChar: -1 }, el);
+		if (el) {
+			// The line is drawn outside of any note's group, so it never appears in
+			// a playback event's `elements`. To let callers highlight/animate it in
+			// sync with playback, expose the ABC source range it covers. During a
+			// TimingCallbacks eventCallback, a line covers the current note when
+			// `event.startChar >= data-start-char && event.startChar < data-end-char`.
+			if (run.startChar !== undefined && run.endChar !== undefined) {
+				renderer.paper.setAttributeOnElement(el, {
+					"data-start-char": run.startChar,
+					"data-end-char": run.endChar
+				});
+			}
+			selectables.wrapSvgEl({ el_type: "extension", startChar: run.startChar, endChar: run.endChar }, el);
+		}
 	}
 	return null;
 }

--- a/src/write/draw/lyric-extension.js
+++ b/src/write/draw/lyric-extension.js
@@ -1,0 +1,89 @@
+var printLine = require('./print-line');
+
+// Draws the melisma / continuation lines requested by "_" in a w: field.
+//
+// The parser marks every note covered by a melisma with a lyric entry whose
+// divider is "_" (the note carrying the syllable ends with "_", and each note
+// it is held over gets an empty syllable with a "_" divider). Rather than
+// printing a separate underscore glyph under each of those notes - which reads
+// as a broken row of dashes - we join a run of covered notes into a single
+// unbroken horizontal line beneath the lyric.
+//
+// Runs are computed per verse (a tune can have several w: lines) and are allowed
+// to cross barlines, matching normal melisma behaviour.
+function drawLyricExtensions(renderer, params, selectables) {
+	var children = params.children;
+	var verseCount = 0;
+	for (var i = 0; i < children.length; i++) {
+		var abcelem = children[i].abcelem;
+		if (abcelem && abcelem.lyric && abcelem.lyric.length > verseCount)
+			verseCount = abcelem.lyric.length;
+	}
+
+	for (var verse = 0; verse < verseCount; verse++)
+		drawVerseExtensions(renderer, children, verse, selectables);
+}
+
+function lyricChild(abselem) {
+	if (!abselem.children)
+		return null;
+	for (var i = 0; i < abselem.children.length; i++) {
+		if (abselem.children[i].type === 'lyric')
+			return abselem.children[i];
+	}
+	return null;
+}
+
+function drawVerseExtensions(renderer, children, verse, selectables) {
+	var run = null; // { startX, endX, y }
+	for (var i = 0; i < children.length; i++) {
+		var child = children[i];
+		if (child.type === 'bar')
+			continue; // a melisma may be held across a barline
+		if (child.type !== 'note') {
+			run = flush(renderer, run, selectables);
+			continue;
+		}
+		var ly = child.abcelem.lyric ? child.abcelem.lyric[verse] : undefined;
+		if (!ly || ly.divider !== '_') {
+			run = flush(renderer, run, selectables);
+			continue;
+		}
+		var relElem = lyricChild(child);
+		if (!relElem || relElem.pitch === undefined) {
+			run = flush(renderer, run, selectables);
+			continue;
+		}
+		var fontSize = relElem.dim && relElem.dim.font ? relElem.dim.font.size : 0;
+		// The lyric is drawn with its baseline one font-size below relElem.pitch,
+		// and each additional verse is offset by 1.2em (see svg.js). The extender
+		// line sits on that baseline.
+		var y = renderer.calcY(relElem.pitch) + fontSize + verse * 1.2 * fontSize;
+
+		if (ly.syllable && ly.syllable.length > 0) {
+			// This note carries the syllable that begins the melisma.
+			run = flush(renderer, run, selectables);
+			run = { startX: relElem.x + relElem.w / 2 + 2, endX: relElem.x, y: y };
+		} else if (run) {
+			// A bare "_": extend the current line to cover this note.
+			run.endX = relElem.x;
+			run.y = y;
+		}
+	}
+	flush(renderer, run, selectables);
+}
+
+function flush(renderer, run, selectables) {
+	if (run) {
+		// If nothing was held over (a trailing "_" with no following note) draw a
+		// short stub so the melisma is still visible.
+		var endX = Math.max(run.endX, run.startX + 6);
+		var klass = renderer.controller.classes.generate('lyric-extension');
+		var el = printLine(renderer, run.startX, endX, run.y, klass, 'lyric-extension', 0.6);
+		if (el)
+			selectables.wrapSvgEl({ el_type: "extension", startChar: -1, endChar: -1 }, el);
+	}
+	return null;
+}
+
+module.exports = drawLyricExtensions;

--- a/src/write/draw/voice.js
+++ b/src/write/draw/voice.js
@@ -7,6 +7,7 @@ var drawTie = require('./tie');
 var drawBeam = require('./beam');
 var renderText = require('./text');
 var drawAbsolute = require('./absolute');
+var drawLyricExtensions = require('./lyric-extension');
 
 function drawVoice(renderer, params, bartop, selectables, staffPos) {
 	var width = params.w - 1;
@@ -50,6 +51,8 @@ function drawVoice(renderer, params, bartop, selectables, staffPos) {
 	}
 
 	renderer.controller.classes.startMeasure();
+
+	drawLyricExtensions(renderer, params, selectables);
 
 	for (i = 0; i < params.beams.length; i++) {
 		var beam = params.beams[i];

--- a/tests/all.html
+++ b/tests/all.html
@@ -60,6 +60,7 @@
 <script src="parse/start-char.test.js"></script>
 <script src="parse/book_parser.test.js"></script>
 <script src="parse/tie-slur.test.js"></script>
+<script src="parse/lyrics.test.js"></script>
 <script src="parse/voices-array.test.js"></script>
 
 <script src="../node_modules/@tarp/require/require.min.js"></script>

--- a/tests/parse/lyrics.test.js
+++ b/tests/parse/lyrics.test.js
@@ -1,0 +1,44 @@
+describe("Parser Lyrics", function() {
+	// ABC 2.1: standalone _ in w: extends the melisma/continuation line under the note
+	var abcMelismaUnderscore =
+		"X:1\n" +
+		"K:C\n" +
+		"C D C\n" +
+		"w: ka-TON_ _\n"
+
+	it("standalone _ extends continuation line (divider is _)", function() {
+		var visualObj = abcjs.renderAbc("paper", abcMelismaUnderscore, {});
+		var voice = visualObj[0].lines[0].staff[0].voices[0];
+		var notes = voice.filter(function(el) { return el.el_type === 'note'; });
+
+		chai.assert.equal(notes.length, 3, "should have 3 notes");
+
+		// Note 1 (C): "ka" with hyphen divider
+		chai.assert.deepEqual(notes[0].lyric, [{syllable: "ka", divider: "-"}], "note 1 lyric");
+
+		// Note 2 (D): "TON" with underscore divider (start of extension line)
+		chai.assert.deepEqual(notes[1].lyric, [{syllable: "TON", divider: "_"}], "note 2 lyric");
+
+		// Note 3 (C): empty syllable with underscore divider (extension line continues)
+		chai.assert.deepEqual(notes[2].lyric, [{syllable: "", divider: "_"}], "note 3 lyric should extend the line");
+	});
+
+	var abcMelismaMultipleUnderscores =
+		"X:1\n" +
+		"K:C\n" +
+		"C D E F\n" +
+		"w: word_ _ _\n"
+
+	it("multiple consecutive _ each extend the continuation line", function() {
+		var visualObj = abcjs.renderAbc("paper", abcMelismaMultipleUnderscores, {});
+		var voice = visualObj[0].lines[0].staff[0].voices[0];
+		var notes = voice.filter(function(el) { return el.el_type === 'note'; });
+
+		chai.assert.equal(notes.length, 4, "should have 4 notes");
+
+		chai.assert.deepEqual(notes[0].lyric, [{syllable: "word", divider: "_"}], "note 1 lyric");
+		chai.assert.deepEqual(notes[1].lyric, [{syllable: "", divider: "_"}], "note 2 lyric should extend");
+		chai.assert.deepEqual(notes[2].lyric, [{syllable: "", divider: "_"}], "note 3 lyric should extend");
+		chai.assert.deepEqual(notes[3].lyric, [{syllable: "", divider: "_"}], "note 4 lyric should extend");
+	});
+});

--- a/tests/parse/lyrics.test.js
+++ b/tests/parse/lyrics.test.js
@@ -41,4 +41,48 @@ describe("Parser Lyrics", function() {
 		chai.assert.deepEqual(notes[2].lyric, [{syllable: "", divider: "_"}], "note 3 lyric should extend");
 		chai.assert.deepEqual(notes[3].lyric, [{syllable: "", divider: "_"}], "note 4 lyric should extend");
 	});
+
+	it("renders one continuous extension line, not a row of underscores", function() {
+		abcjs.renderAbc("paper", abcMelismaMultipleUnderscores, {add_classes: true});
+		var svg = document.querySelector("#paper svg");
+
+		// A single unbroken line covers the whole melisma rather than one glyph per note.
+		var lines = svg.querySelectorAll('[data-name="lyric-extension"]');
+		chai.assert.equal(lines.length, 1, "should draw a single continuous line");
+
+		// The underscores must not be printed as text.
+		var lyrics = svg.querySelectorAll('[data-name="lyric"]');
+		lyrics.forEach(function(el) {
+			chai.assert.equal(el.textContent.indexOf("_"), -1, "underscore should not be drawn as a glyph");
+		});
+	});
+
+	// A melisma can be held across a barline and should stay a single line.
+	var abcMelismaAcrossBar =
+		"X:1\n" +
+		"K:C\n" +
+		"C D | E F\n" +
+		"w: la_ _ _ _\n"
+
+	it("draws a single line across a barline", function() {
+		abcjs.renderAbc("paper", abcMelismaAcrossBar, {add_classes: true});
+		var svg = document.querySelector("#paper svg");
+		var lines = svg.querySelectorAll('[data-name="lyric-extension"]');
+		chai.assert.equal(lines.length, 1, "melisma across a barline is still one line");
+	});
+
+	// Each verse gets its own independent extension line.
+	var abcMelismaTwoVerses =
+		"X:1\n" +
+		"K:C\n" +
+		"C D E\n" +
+		"w: a_ _ b\n" +
+		"w: c d_ _\n"
+
+	it("draws a separate line per verse", function() {
+		abcjs.renderAbc("paper", abcMelismaTwoVerses, {add_classes: true});
+		var svg = document.querySelector("#paper svg");
+		var lines = svg.querySelectorAll('[data-name="lyric-extension"]');
+		chai.assert.equal(lines.length, 2, "one line for each verse's melisma");
+	});
 });


### PR DESCRIPTION
Hi Paul, first of all: thank you for the excellent library.

While working on a personal project using the library, I noticed that the lyrics continuation line doesn't appear when it is present in the input w: field. 

According to the standard for ABC 2.1, a standalone _ in a w: field should draw a continuation line under the note. For instance, in example 5 in the Lyrics section on [this page](https://abcnotation.com/examples#lyrics), the "ble" is continued until the final note in the line. 

<img width="858" height="123" alt="image" src="https://github.com/user-attachments/assets/ff3d7f9b-fb62-41d1-80c3-1fea064c24e0" />

Instead, in a similar arrangement, the output from abcjs looks like this, where the should be underscore continuations.

<img width="1173" height="181" alt="image" src="https://github.com/user-attachments/assets/faf78480-11cd-40ad-af0c-0f687413b150" />

This fix doesn't do exactly the same behaviour as in the reference above, but instead by setting both the divider and the syllable in the parser output to `_`, each continuation syllable has an underscore which sets a clearer intent for the reader of the music - as shown in the new output below.

<img width="1140" height="186" alt="image" src="https://github.com/user-attachments/assets/484dfa1a-d85f-412d-a590-6362f96dd756" />

This PR adds a parse test covering both single and multiple consecutive _ usage.

I'll acknowledge that I wrote this with Claude Code but I couldn't see an explicit AI-assisted code generation policy for your project.
