### PR TITLE
Fix inline key changes leaking between voices

### DIFF
--- a/src/parse/abc_parse_key_voice.js
+++ b/src/parse/abc_parse_key_voice.js
@@ -85,7 +85,18 @@ var parseKeyVoice = {};
 		key.accidentals.forEach(function(k) {
 		ret.accidentals.push(Object.assign({},k));
 		});
+		if (key.explicitAccidentals) {
+			ret.explicitAccidentals = [];
+			key.explicitAccidentals.forEach(function(k) {
+				ret.explicitAccidentals.push(Object.assign({},k));
+			});
+		}
 		return ret;
+	};
+
+	var setVoiceKey = function() {
+		if (multilineVars.currentVoice)
+			multilineVars.currentVoice.key = parseKeyVoice.deepCopyKey(multilineVars.key);
 	};
 
 	var pitches = {A: 5, B: 6, C: 0, D: 1, E: 2, F: 3, G: 4, a: 12, b: 13, c: 7, d: 8, e: 9, f: 10, g: 11};
@@ -230,18 +241,36 @@ var parseKeyVoice = {};
 				multilineVars.key = { root: "HP", accidentals: [], acc: "", mode: "" };
 				ret.foundKey = true;
 				tokens.shift();
+				if (isInline)
+					setVoiceKey();
+				else {
+					multilineVars.globalKey = parseKeyVoice.deepCopyKey(multilineVars.key);
+					setVoiceKey();
+				}
 				break;
 			case 'Hp':
 				parseDirective.addDirective("bagpipes");
 				multilineVars.key = { root: "Hp", accidentals: [{acc: 'natural', note: 'g'}, {acc: 'sharp', note: 'f'}, {acc: 'sharp', note: 'c'}], acc: "", mode: "" };
 				ret.foundKey = true;
 				tokens.shift();
+				if (isInline)
+					setVoiceKey();
+				else {
+					multilineVars.globalKey = parseKeyVoice.deepCopyKey(multilineVars.key);
+					setVoiceKey();
+				}
 				break;
 			case 'none':
 				// we got the none key - that's the same as C to us
 				multilineVars.key = { root: "none", accidentals: [], acc: "", mode: "" };
 				ret.foundKey = true;
 				tokens.shift();
+				if (isInline)
+					setVoiceKey();
+				else {
+					multilineVars.globalKey = parseKeyVoice.deepCopyKey(multilineVars.key);
+					setVoiceKey();
+				}
 				break;
 			default:
 				var retPitch = tokenizer.getKeyPitch(tokens[0].token);
@@ -309,6 +338,12 @@ var parseKeyVoice = {};
 							}
 						}
 					}
+					if (isInline)
+						setVoiceKey();
+					else {
+						multilineVars.globalKey = parseKeyVoice.deepCopyKey(multilineVars.key);
+						setVoiceKey();
+					}
 				}
 				break;
 		}
@@ -357,6 +392,12 @@ var parseKeyVoice = {};
 						}
 					}
 				}
+			}
+			if (isInline)
+				setVoiceKey();
+			else {
+				multilineVars.globalKey = parseKeyVoice.deepCopyKey(multilineVars.key);
+				setVoiceKey();
 			}
 		}
 
@@ -499,6 +540,10 @@ var parseKeyVoice = {};
 				return // there was no change so don't reset it.
 		}
 		multilineVars.currentVoice = currentVoice;
+		if (currentVoice.key)
+			multilineVars.key = parseKeyVoice.deepCopyKey(currentVoice.key);
+		else if (multilineVars.globalKey)
+			multilineVars.key = parseKeyVoice.deepCopyKey(multilineVars.globalKey);
 		return tuneBuilder.setCurrentVoice(currentVoice.staffNum, currentVoice.index, id);
 	};
 

--- a/tests/visual/parsing.test.js
+++ b/tests/visual/parsing.test.js
@@ -186,6 +186,44 @@ describe("Parsing", function () {
 		{"line":3,"staff":0,"type":"bar","style":"bar_thin"}
 	]
 
+	var abcInlineKeyPerVoice = "X:1\n" +
+		"M:4/4\n" +
+		"L:1/8\n" +
+		"K:Edor\n" +
+		"V:1\n" +
+		"C2 D2 E2 F2| [K:C] G2 A2 B2 c2|]\n" +
+		"V:2\n" +
+		"C2 D2 E2 F2| [K:C] G2 A2 B2 c2|]\n"
+
+	var expectedInlineKeyPerVoice = [
+		{"line":0,"staff":0,"type":"initial-clef","style":"treble"},
+		{"line":0,"staff":0,"type":"initial-key","name":"EDor","accidentals":"f sharp,c sharp"},
+		{"line":0,"staff":0,"type":"note","duration":0.25,"pitches":"C"},
+		{"line":0,"staff":0,"type":"note","duration":0.25,"pitches":"D"},
+		{"line":0,"staff":0,"type":"note","duration":0.25,"pitches":"E"},
+		{"line":0,"staff":0,"type":"note","duration":0.25,"pitches":"F"},
+		{"line":0,"staff":0,"type":"bar","style":"bar_thin"},
+		{"line":0,"staff":0,"type":"key","name":"C","accidentals":"f natural,c natural"},
+		{"line":0,"staff":0,"type":"note","duration":0.25,"pitches":"G"},
+		{"line":0,"staff":0,"type":"note","duration":0.25,"pitches":"A"},
+		{"line":0,"staff":0,"type":"note","duration":0.25,"pitches":"B"},
+		{"line":0,"staff":0,"type":"note","duration":0.25,"pitches":"c"},
+		{"line":0,"staff":0,"type":"bar","style":"bar_thin_thick"},
+		{"line":0,"staff":1,"type":"initial-clef","style":"treble"},
+		{"line":0,"staff":1,"type":"initial-key","name":"EDor","accidentals":"f sharp,c sharp"},
+		{"line":0,"staff":1,"type":"note","duration":0.25,"pitches":"C"},
+		{"line":0,"staff":1,"type":"note","duration":0.25,"pitches":"D"},
+		{"line":0,"staff":1,"type":"note","duration":0.25,"pitches":"E"},
+		{"line":0,"staff":1,"type":"note","duration":0.25,"pitches":"F"},
+		{"line":0,"staff":1,"type":"bar","style":"bar_thin"},
+		{"line":0,"staff":1,"type":"key","name":"C","accidentals":"f natural,c natural"},
+		{"line":0,"staff":1,"type":"note","duration":0.25,"pitches":"G"},
+		{"line":0,"staff":1,"type":"note","duration":0.25,"pitches":"A"},
+		{"line":0,"staff":1,"type":"note","duration":0.25,"pitches":"B"},
+		{"line":0,"staff":1,"type":"note","duration":0.25,"pitches":"c"},
+		{"line":0,"staff":1,"type":"bar","style":"bar_thin_thick"}
+	]
+
 
 	var abcBarNumberSubtitle = "X:1\n" +
 		"T:song\n" +
@@ -268,6 +306,11 @@ CDEF|GFED|CDE!~(!F|
 		const ret = flattenResults(abcKeyWarn)
 		//console.log(JSON.stringify(ret))
 		chai.assert.deepStrictEqual(ret, expectedKeyWarn, "KeyWarn");
+	})
+
+	it("inline-key-per-voice", function () {
+		const ret = flattenResults(abcInlineKeyPerVoice)
+		chai.assert.deepStrictEqual(ret, expectedInlineKeyPerVoice, "InlineKeyPerVoice");
 	})
 
 	it("dynamics-over-line", function () {


### PR DESCRIPTION
fixes #1109

# Description

Inline `[K:]` changes were being stored only in the shared parser key state. When parsing switched from one voice to another, a key change from the previous voice could leak into the next voice’s initial staff key.

This change stores the running key per voice and restores it when switching voices. New voices still start from the global key, while existing voices resume from their own last key state.

  # Testing

- Added a regression test for inline key changes across multiple voices.
- Verified the issue example keeps `V:2` starting in EDor after `V:1` changes inline to C.
- Ran `npm run build:basic` locally for syntax/build validation.