### PR TITLE
Fix inline meter change rendering in grand staff

### DIFF
--- a/src/parse/abc_parse_header.js
+++ b/src/parse/abc_parse_header.js
@@ -356,7 +356,9 @@ var ParseHeader = function(tokenizer, warn, multilineVars, tune, tuneBuilder) {
 					return [ e-i+1+ws ];
 				case "[M:":
 					var meter = this.setMeter(line.substring(i+3, e));
-					if (tuneBuilder.hasBeginMusic() && meter)
+					if (startLine && multilineVars.currentVoice && meter)
+						multilineVars.staves[multilineVars.currentVoice.staffNum].meter = meter;
+					else if (tuneBuilder.hasBeginMusic() && meter)
 						tuneBuilder.appendStartingElement('meter', startChar, endChar, meter);
 					else
 						multilineVars.meter = meter;

--- a/tests/visual/layout.test.js
+++ b/tests/visual/layout.test.js
@@ -189,6 +189,30 @@ G3GG3G d3dd3d | GG3GG3 dd3dd3 | GG3G3G dd3d3d | G3GGG3 d3ddd3 |
 G3G G3G d3d d3d | GG3 GG3 dd3 dd3 | GG3 G3G dd3 d3d | G3G GG3 d3d dd3 | 
 `
 
+	var abcGrandStaffInlineMeter = `X:1
+T:Time sig change test
+%%barnumbers 1
+%%measurenb 0
+%%score {R|L}
+%%stretchlast 1
+Q:"Misterioso" 1/4=80
+M:2/4
+L:1/4
+V:R clef=treble
+V:L clef=bass
+K:Gmaj
+[V:R] x x/ G/ | G2 | G2 | G2 |
+[V:L] x x/ z/ | C2 | C2 | C2 |
+%
+%%vskip 40
+[V:R] [M:4/4] G4 | G4 | G4 | G4 |
+[V:L] [M:4/4] C4 | C4 | C4 | C4 |
+%
+%%vskip 40
+[V:R] G4 | G4 | G4 | G4 |]
+[V:L] C4 | C4 | C4 | C4 |]
+`
+
 	var expectedPartialStemDirection = [
 		[{"l":79,"r":133},{"l":113,"r":109}],
 		[{"l":151,"r":206},{"l":185,"r":180}],
@@ -350,6 +374,20 @@ G3G G3G d3d d3d | GG3 GG3 dd3 dd3 | GG3 G3G dd3 d3d | G3G GG3 d3d dd3 |
 		console.log(out.replace(/\],\[/g, '],\n[').replace("[[", "[\n[").replace("]]", "]\n]"))
 		chai.assert.deepEqual(beams, expectedPartialStemDirection)
 
+	})
+
+	it("grand-staff-inline-meter", function() {
+		var visualObj = abcjs.renderAbc("paper", abcGrandStaffInlineMeter, {});
+		var line = visualObj[0].lines[1];
+		var staff = line.staff;
+		chai.assert.equal(staff[0].meter.value[0].num, "4");
+		chai.assert.equal(staff[0].meter.value[0].den, "4");
+		chai.assert.equal(staff[1].meter.value[0].num, "4");
+		chai.assert.equal(staff[1].meter.value[0].den, "4");
+		chai.assert.equal(staff[0].brace, "start");
+		chai.assert.equal(staff[1].brace, "end");
+		chai.assert.equal(staff[0].connectBarLines, "start");
+		chai.assert.equal(staff[1].connectBarLines, "end");
 	})
 
 })


### PR DESCRIPTION
Fixes #1043

## Summary

This fixes grand staff rendering when both voices repeat an inline time signature change at the start of a new system, such as

```abc
%%score {R|L}
[V:R] [M:4/4] G4 |
[V:L] [M:4/4] C4 |
```

Previously, the inline `[M:...]` could be appended to the wrong already-started staff/voice state, leaving the new system with mismatched staff metadata. That caused the line with the meter change to lose proper grand staff rendering.

## Changes

- Treat start-of-line inline meter changes for the current voice as staff-starting meter state.
- Preserve brace and connected barline metadata for both staves in the grand staff.
- Add a regression test for repeated inline meter changes in %%score {R|L}.

## Verification

- Added grand-staff-inline-meter visual regression coverage.
- Ran a focused parser check confirming both staves on the changed system keep:
  - M:4/4
  - brace start/end
  - connected barline start/end